### PR TITLE
test: fix a race in TestCoordinator_SetStore_PersistsReplicationJob

### DIFF
--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -32,6 +32,11 @@ type memClient struct {
 	// getFn, if non-nil, overrides the default Get behaviour.  Useful for
 	// simulating sequences of transient failures in retry tests.
 	getFn func(key string) ([]byte, error)
+	// putGate, if non-nil, blocks Put until the channel is closed.  Tests that
+	// assert on state which only exists *while* a transfer is in flight need
+	// the transfer held open; without it the worker and the drain goroutine can
+	// run to completion before the assertion executes.
+	putGate chan struct{}
 }
 
 func newMemClient(objs map[string][]byte) *memClient {
@@ -63,6 +68,14 @@ func (m *memClient) Get(_ context.Context, key string, _, _ int64) ([]byte, erro
 func (m *memClient) Put(_ context.Context, key string, data []byte) error {
 	if m.putErr != nil {
 		return m.putErr
+	}
+	// Read the gate under the lock, then wait outside it: blocking while holding
+	// m.mu would deadlock any concurrent hasKey/keys call.
+	m.mu.Lock()
+	gate := m.putGate
+	m.mu.Unlock()
+	if gate != nil {
+		<-gate
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -140,6 +153,17 @@ func (m *memClient) setHealthErr(err error) {
 	m.mu.Lock()
 	m.healthErr = err
 	m.mu.Unlock()
+}
+
+// blockPuts makes every subsequent Put on this client wait.  The returned
+// function releases them and is safe to call more than once.
+func (m *memClient) blockPuts() (release func()) {
+	gate := make(chan struct{})
+	m.mu.Lock()
+	m.putGate = gate
+	m.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
 }
 
 func makeMount(name string, role types.SiteRole, objs map[string][]byte) (*site.SiteMount, *memClient) {
@@ -636,16 +660,28 @@ func TestCoordinator_SetStore_PersistsReplicationJob(t *testing.T) {
 	t.Parallel()
 
 	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
-	backup, _ := makeMount("backup", types.SiteRoleBackup, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// A persisted job is deleted by the drain goroutine as soon as the transfer
+	// completes, so its presence in the store is transient. Hold the destination
+	// write open for the duration of the assertion; otherwise the worker and the
+	// drain can both finish before GetPendingJobs runs and the job is legitimately
+	// gone. That is what made this test flake on CI, where two cores and a loaded
+	// runner widen the window enough for the race to land.
+	release := backupClient.blockPuts()
 
 	store := metadata.NewMemoryStore()
 	c := New(primary, backup)
 	c.SetStore(store)
 	c.Start(ctx)
+	// Defers run LIFO, so this releases the blocked transfer *before* Stop runs.
+	// The reverse order would have Stop wait on a worker parked inside Put, which
+	// is the shutdown hang tracked in #83.
 	defer c.Stop()
+	defer release()
 
 	if err := c.Put(ctx, "data/sample.bam", []byte("genome")); err != nil {
 		t.Fatalf("Put: %v", err)


### PR DESCRIPTION
The `test` job failed on main immediately after #125 merged. Not a regression from that PR — the same SHA passed all nine jobs on the PR itself. It is a pre-existing race in the test that the CI runner exposes.

## What's wrong

The test asserts "the replication job must appear in the store immediately after `Put` returns", then reads the store with nothing holding the transfer open:

```go
if err := c.Put(ctx, "data/sample.bam", []byte("genome")); err != nil { ... }
jobs, err := store.GetPendingJobs(ctx)   // races the drain goroutine
```

A persisted job is deleted by the drain the moment its transfer completes, so its presence in the store is **transient**. Against an in-memory fake, `Put` → enqueue → transfer → drain-delete can all complete before the next statement runs, and the job is legitimately gone.

Two cores under load is what makes it land. `-count=40` locally passes; the runner does not.

## Reproduction

Inserting `runtime.Gosched()` between the two statements loses the job on 2 of 3 runs, which is the same interleaving the runner hits by scheduling.

## Fix

Hold the destination write open for the assertion, which is the condition the test actually means: a job is in the store *while* its transfer is in flight. `memClient` gains an optional `putGate` and a `blockPuts()` helper.

Three details a reviewer should check:

- The gate is read under `m.mu` and waited on **outside** it — blocking while holding the mutex would deadlock any concurrent `hasKey`/`keys` call.
- `defer c.Stop()` is registered **before** `defer release()`, so LIFO releases the transfer first. The reverse parks `Stop` on a worker blocked inside `Put` — the shutdown hang in #83 — and the test would hang rather than fail.
- `blockPuts` wraps `close` in a `sync.Once`, so releasing twice is safe.

## Verified

- Gate holds the job across 500 forced yields, 5/5 runs (vs. 2/3 losses un-gated)
- `go test -race -timeout=5m ./...` — all packages pass
- `-count=30` on the test, and `-count=25 -cpu=1,2` to approximate the runner
- `gofmt -l .` empty, `go vet ./...` clean

## Scope

No production code changes — one test file. The two sibling `GetPendingJobs` assertions were checked and are sound: one polls toward empty (the stable end state), the other asserts a negative after an injected persist failure.

Worth noting this is a *test* defect, not one of the reviewed findings — but it sits squarely in the gap #82–#86 describe: the suite has no coverage that exercises the coordinator's goroutines against a busy worker, so timing-dependent assertions like this one went unnoticed.