### PR TITLE
fix: v0.2.2 worker panic and client truncation (#72, #74)

### DIFF
--- a/internal/replication/worker.go
+++ b/internal/replication/worker.go
@@ -21,6 +21,15 @@
 // channel returned by Events to observe progress.  The channel is buffered to
 // the same depth as the work queue; if it fills, events are dropped (logged)
 // rather than blocking the worker.
+//
+// # Panic containment
+//
+// The worker goroutine is a long-lived part of the coordinator daemon, so a
+// panic in it would terminate the whole process.  Each job is therefore run
+// under a recover: the panic value and stack are logged at Error and the job
+// settles as EventFailed, keeping the failure scoped to the object that caused
+// it.  This is containment, not suppression — a recovered panic is still a bug
+// and is logged as loudly as the process can log it.
 package replication
 
 import (
@@ -30,6 +39,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -168,9 +178,37 @@ func (w *Worker) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case job := <-w.queue:
-			w.processJob(ctx, job)
+			w.runJob(ctx, job)
 		}
 	}
+}
+
+// runJob invokes processJob with a last-resort panic backstop.
+//
+// safeTransfer already converts a panic inside transfer into an ordinary
+// attempt error, which is where a panic is overwhelmingly likely to originate.
+// This outer recover covers the remainder of processJob — the retry loop, the
+// log calls that dereference job fields, and emit — so that no panic in the
+// worker can terminate the process that hosts it.  It emits EventFailed before
+// returning, because the coordinator deletes a persisted job from the metadata
+// store only on a terminal event; skipping it would leave an orphaned job that
+// is re-enqueued on every restart.
+func (w *Worker) runJob(ctx context.Context, job ReplicationJob) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("replication: recovered panic while processing job",
+				"key", job.Key,
+				"panic", fmt.Sprintf("%v", r),
+				"stack", string(debug.Stack()))
+			w.emit(ReplicationEvent{
+				Job:     job,
+				Type:    EventFailed,
+				Attempt: MaxRetries,
+				Err:     fmt.Errorf("replication: panic processing job: %v", r),
+			})
+		}
+	}()
+	w.processJob(ctx, job)
 }
 
 func (w *Worker) processJob(ctx context.Context, job ReplicationJob) {
@@ -201,7 +239,7 @@ func (w *Worker) processJob(ctx context.Context, job ReplicationJob) {
 			}
 		}
 
-		contentHash, err := transfer(ctx, job)
+		contentHash, err := safeTransfer(ctx, job)
 		if err != nil {
 			lastErr = err
 			slog.Warn("replication: transfer attempt failed",
@@ -231,6 +269,43 @@ func (w *Worker) emit(ev ReplicationEvent) {
 	}
 }
 
+// safeTransfer calls transfer and converts a panic into an ordinary error so
+// that one malformed object cannot terminate the coordinator process.
+//
+// A panic here is a bug, and the retry loop will re-run the same input twice
+// more before giving up — which is the point: the failure is reported through
+// the normal EventFailed path with the job's key attached, rather than as a
+// process-wide crash whose only record is stderr on a daemon that is no longer
+// running.  The panic value and stack are logged at Error so the bug is not
+// silently swallowed.
+func safeTransfer(ctx context.Context, job ReplicationJob) (hash string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("replication: recovered panic during transfer",
+				"key", job.Key,
+				"src", job.SourceSite.Name(),
+				"dst", job.DestSite.Name(),
+				"panic", fmt.Sprintf("%v", r),
+				"stack", string(debug.Stack()))
+			hash = ""
+			err = fmt.Errorf("replication: panic during transfer of %q: %v", job.Key, r)
+		}
+	}()
+	return transfer(ctx, job)
+}
+
+// shortChecksum truncates a checksum for logging, without assuming its length.
+// Checksums originate in S3 user metadata and are not guaranteed to be 64-char
+// SHA-256 hex: a non-ObjectFS backend or an ETag-derived value can be shorter
+// (#72).
+func shortChecksum(s string) string {
+	const n = 8
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
 // transfer performs the actual byte movement: GET from source, PUT to dest.
 // Returns the SHA-256 hex of the transferred content and any error.
 //
@@ -250,7 +325,7 @@ func transfer(ctx context.Context, job ReplicationJob) (string, error) {
 		if destErr == nil && destInfo != nil && destInfo.Checksum == srcInfo.Checksum {
 			slog.Info("replication: skipping transfer, dest already has matching content",
 				"key", job.Key,
-				"checksum", srcInfo.Checksum[:8]+"...",
+				"checksum", shortChecksum(srcInfo.Checksum),
 				"dest", job.DestSite.Name())
 			return srcInfo.Checksum, nil
 		}

--- a/internal/replication/worker_test.go
+++ b/internal/replication/worker_test.go
@@ -3,6 +3,7 @@ package replication
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -86,6 +87,31 @@ func (f *failClient) putCallCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.data) // approximation; use a counter for exact counts
+}
+
+// checksumClient is an ObjectFSClient whose Head returns a fixed checksum, so
+// tests can drive the replication fast path with arbitrary checksum values —
+// including ones shorter than the 8 characters the log line used to slice (#72).
+type checksumClient struct {
+	*failClient
+	checksum string
+}
+
+func newChecksumClient(objs map[string][]byte, checksum string) *checksumClient {
+	return &checksumClient{failClient: newFailClient(objs), checksum: checksum}
+}
+
+func (c *checksumClient) Head(_ context.Context, key string) (*objectfstypes.ObjectInfo, error) {
+	return &objectfstypes.ObjectInfo{Key: key, Checksum: c.checksum}, nil
+}
+
+// panicClient panics on Get, standing in for any bug reachable from transfer.
+type panicClient struct {
+	*failClient
+}
+
+func (p *panicClient) Get(_ context.Context, _ string, _, _ int64) ([]byte, error) {
+	panic("synthetic transfer panic")
 }
 
 // countingClient wraps failClient and tracks call counts.
@@ -553,4 +579,165 @@ func TestWorker_ContextCancellation(t *testing.T) {
 	}
 
 	w.Stop()
+}
+
+// ─── #72: short checksums and panic containment ────────────────────────────────
+
+// TestShortChecksum covers the log-truncation helper at and around the boundary.
+// Before the fix the call site was srcInfo.Checksum[:8], which panics for every
+// input shorter than 8 bytes.
+func TestShortChecksum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"ab", "ab"},                    // the reproduced panic: length 2
+		{"1234567", "1234567"},          // one below the boundary
+		{"12345678", "12345678"},        // exactly the boundary: no ellipsis
+		{"123456789", "12345678..."},    // one above
+		{"deadbeefcafe", "deadbeef..."}, // typical hex prefix
+		{"héllo", "héllo"},              // 6 bytes, 5 runes: no slice
+		{"héllo-world", "héllo-w..."},   // multi-byte, sliced on a rune boundary
+	}
+	for _, tt := range tests {
+		if got := shortChecksum(tt.in); got != tt.want {
+			t.Errorf("shortChecksum(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestTransfer_ShortMatchingChecksum_DoesNotPanic is the regression test for
+// #72.  Both sites report the same 2-character checksum, which takes the fast
+// path straight into the log line that used to slice [:8].  On the pre-fix tree
+// this panics with "slice bounds out of range [:8] with length 2"; the panic is
+// what fails the test, so no assertion on it is needed beyond reaching the end.
+func TestTransfer_ShortMatchingChecksum_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	const short = "ab" // shorter than the 8 bytes the log line sliced
+	srcClient := newChecksumClient(map[string][]byte{"genome.bam": []byte("data")}, short)
+	dstClient := newChecksumClient(nil, short)
+	src := site.New("src", types.SiteRolePrimary, srcClient)
+	dst := site.New("dst", types.SiteRoleBackup, dstClient)
+
+	hash, err := transfer(context.Background(), ReplicationJob{
+		SourceSite: src, DestSite: dst, Key: "genome.bam",
+	})
+	if err != nil {
+		t.Fatalf("transfer: unexpected error: %v", err)
+	}
+	if hash != short {
+		t.Errorf("fast path should return the source checksum: got %q, want %q", hash, short)
+	}
+	// The fast path must have skipped the copy entirely.
+	if dstClient.hasKey("genome.bam") {
+		t.Error("fast path transferred data despite matching checksums")
+	}
+}
+
+// TestWorker_ShortMatchingChecksum_WorkerSurvives exercises the same input
+// through the live worker goroutine.  On the pre-fix tree the panic is
+// unrecovered and takes down the test binary — which is exactly what it does to
+// the coordinator process in production.
+func TestWorker_ShortMatchingChecksum_WorkerSurvives(t *testing.T) {
+	t.Parallel()
+
+	srcClient := newChecksumClient(map[string][]byte{"a.bam": []byte("data")}, "ab")
+	dstClient := newChecksumClient(nil, "ab")
+	src := site.New("src", types.SiteRolePrimary, srcClient)
+	dst := site.New("dst", types.SiteRoleBackup, dstClient)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(8)
+	w.Start(ctx)
+	defer w.Stop()
+
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "a.bam"}); err != nil {
+		t.Fatalf("Enqueue: unexpected error: %v", err)
+	}
+
+	var got ReplicationEvent
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && got.Type == "" {
+		ev, ok := drainEvent(t, w, 200*time.Millisecond)
+		if ok && (ev.Type == EventCompleted || ev.Type == EventFailed) {
+			got = ev
+		}
+	}
+	if got.Type != EventCompleted {
+		t.Fatalf("expected EventCompleted, got %q (err: %v)", got.Type, got.Err)
+	}
+	if got.ContentHash != "ab" {
+		t.Errorf("ContentHash: got %q, want %q", got.ContentHash, "ab")
+	}
+
+	// The worker must still be alive and able to process the next job.
+	srcClient.checksum = "" // force the slow path this time
+	dstClient.checksum = ""
+	srcClient.data["b.bam"] = []byte("more")
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "b.bam"}); err != nil {
+		t.Fatalf("Enqueue second job: unexpected error: %v", err)
+	}
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if dstClient.hasKey("b.bam") {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Error("worker did not process the job after a short-checksum job")
+}
+
+// TestWorker_PanicInTransfer_FailsJobAndKeepsWorkerAlive verifies the panic
+// backstop: an arbitrary panic reachable from transfer settles the job as
+// EventFailed (so the coordinator can delete it from the metadata store) and
+// leaves the worker goroutine running.
+func TestWorker_PanicInTransfer_FailsJobAndKeepsWorkerAlive(t *testing.T) {
+	t.Parallel()
+
+	srcClient := &panicClient{failClient: newFailClient(map[string][]byte{"boom": []byte("x")})}
+	src := site.New("src", types.SiteRolePrimary, srcClient)
+	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(8)
+	w.Start(ctx)
+	defer w.Stop()
+
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "boom"}); err != nil {
+		t.Fatalf("Enqueue: unexpected error: %v", err)
+	}
+
+	var got ReplicationEvent
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && got.Type == "" {
+		ev, ok := drainEvent(t, w, 200*time.Millisecond)
+		if ok && (ev.Type == EventCompleted || ev.Type == EventFailed) {
+			got = ev
+		}
+	}
+	if got.Type != EventFailed {
+		t.Fatalf("expected EventFailed after a panic, got %q", got.Type)
+	}
+	if got.Err == nil || !strings.Contains(got.Err.Error(), "synthetic transfer panic") {
+		t.Errorf("EventFailed.Err should name the panic value; got %v", got.Err)
+	}
+
+	// A healthy job must still go through on the same worker goroutine.
+	good, _ := makeMount("src2", types.SiteRolePrimary, map[string][]byte{"ok": []byte("y")})
+	if err := w.Enqueue(ReplicationJob{SourceSite: good, DestSite: dst, Key: "ok"}); err != nil {
+		t.Fatalf("Enqueue after panic: unexpected error: %v", err)
+	}
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if dstClient.hasKey("ok") {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Error("worker did not process a job after recovering from a panic")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -238,6 +238,10 @@ func (c *Client) Status(ctx context.Context) (StatusResponse, error) {
 	}
 	defer resp.Body.Close()
 
+	// A read error here is deliberately ignored: the status code is what
+	// determines health, and the body only supplies human-readable detail, so a
+	// truncated read degrades the message rather than the answer.  (Bounding
+	// this read is #111.)
 	body, _ := io.ReadAll(resp.Body)
 	text := strings.TrimSpace(string(body))
 
@@ -260,6 +264,11 @@ func (c *Client) Status(ctx context.Context) (StatusResponse, error) {
 // ── Object methods ────────────────────────────────────────────────────────────
 
 // GetObject retrieves the full content of the object at key.
+//
+// GetObject never returns partial content with a nil error: a read that fails
+// mid-body, or a body shorter than the advertised Content-Length, is reported as
+// an error and the partial bytes are discarded (#74).  Callers can therefore
+// treat a nil error as meaning the returned slice is the whole object.
 func (c *Client) GetObject(ctx context.Context, key string) ([]byte, error) {
 	resp, err := c.doGet(ctx, "/api/v1/objects/"+key)
 	if err != nil {
@@ -270,7 +279,28 @@ func (c *Client) GetObject(ctx context.Context, key string) ([]byte, error) {
 	if err := checkStatus(resp, http.StatusOK); err != nil {
 		return nil, err
 	}
-	return io.ReadAll(resp.Body)
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// Discard the partial bytes: returning them alongside an error invites
+		// callers to use whichever value they check first.
+		return nil, fmt.Errorf("read object %q body after %d bytes: %w", key, len(data), err)
+	}
+	// Cross-check against the advertised length: an independent assertion that
+	// does not rely on the transport reporting the truncation.  net/http does
+	// report it (a short Content-Length delimited body surfaces as
+	// io.ErrUnexpectedEOF), but WithHTTPClient lets callers substitute any
+	// RoundTripper, and this check holds regardless of which one is in play.
+	//
+	// resp.ContentLength is -1 when the length is unknown — a chunked response
+	// or an HTTP/1.0 close-delimited body — and the check is then skipped
+	// because there is nothing to compare against.  The coordinator always sets
+	// Content-Length on GET /api/v1/objects, so the check is live in practice.
+	if resp.ContentLength >= 0 && int64(len(data)) != resp.ContentLength {
+		return nil, fmt.Errorf("short object body for %q: got %d bytes, want %d",
+			key, len(data), resp.ContentLength)
+	}
+	return data, nil
 }
 
 // PutObject stores data under key. It returns nil on success.
@@ -440,6 +470,9 @@ func checkStatus(resp *http.Response, wantCode int) error {
 	if resp.StatusCode == wantCode {
 		return nil
 	}
+	// As in Status, a read error is ignored on purpose: an *APIError carrying the
+	// status code and a partial message is strictly better than losing the status
+	// code to a body-read failure.  (Bounding this read is #111.)
 	body, _ := io.ReadAll(resp.Body)
 	// Try to extract {"error":"..."} message.
 	var e struct{ Error string }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,12 +1,16 @@
 package client_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -421,6 +425,252 @@ func TestGetObject_Error(t *testing.T) {
 	if apiErr.StatusCode != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", apiErr.StatusCode)
 	}
+}
+
+// ── GetObject truncation (#74) ─────────────────────────────────────────────────
+
+// rawServer serves a single hand-written HTTP response over a raw TCP
+// connection, then closes it.  This is the only way to produce responses
+// net/http's server refuses to emit — a body shorter than its own
+// Content-Length, or a close-delimited body with no length at all.
+func rawServer(t *testing.T, response string) *client.Client {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Consume the request head; we do not care what it says.
+			conn.Read(make([]byte, 4096))
+			conn.Write([]byte(response))
+			conn.Close()
+		}
+	}()
+	return client.New("http://" + ln.Addr().String())
+}
+
+// TestGetObject_ShortBody_ContentLength is the primary regression test for #74:
+// the response is a 200 with Content-Length: 64 and only 8 bytes of body.  On
+// the pre-fix tree GetObject returned those 8 bytes with a nil error, and
+// `object get -o file` wrote a short file and exited 0.
+func TestGetObject_ShortBody_ContentLength(t *testing.T) {
+	c := rawServer(t, "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: 64\r\n\r\n12345678")
+
+	data, err := c.GetObject(context.Background(), "data/genome.bam")
+	if err == nil {
+		t.Fatalf("expected an error for a truncated body, got nil with %d bytes", len(data))
+	}
+	if data != nil {
+		t.Errorf("partial data must not be returned alongside an error; got %d bytes", len(data))
+	}
+	if !strings.Contains(err.Error(), "genome.bam") {
+		t.Errorf("error should name the key; got %v", err)
+	}
+}
+
+// TestGetObject_ShortBody_NoTransportError covers the case the length check
+// exists for: a transport that hands back fewer bytes than Content-Length
+// advertises without reporting a read error at all.  WithHTTPClient makes this
+// substitution part of the public API, so the check cannot lean on net/http
+// noticing.
+func TestGetObject_ShortBody_NoTransportError(t *testing.T) {
+	hc := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := []byte("12345678")
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Status:        "200 OK",
+			Header:        http.Header{"Content-Type": {"application/octet-stream"}},
+			ContentLength: 64, // claims 64, delivers 8, reports no error
+			Body:          io.NopCloser(bytes.NewReader(body)),
+			Request:       r,
+		}, nil
+	})}
+	c := client.New("http://coordinator.invalid", client.WithHTTPClient(hc))
+
+	data, err := c.GetObject(context.Background(), "big.bin")
+	if err == nil {
+		t.Fatalf("expected an error, got nil with %d bytes", len(data))
+	}
+	if !strings.Contains(err.Error(), "got 8 bytes, want 64") {
+		t.Errorf("error should report both lengths; got %v", err)
+	}
+	if data != nil {
+		t.Errorf("expected nil data, got %d bytes", len(data))
+	}
+}
+
+// TestGetObject_MidBodyReadError covers a body that fails partway with a
+// transport-level error.  The bytes read before the failure must not be
+// returned as success.
+func TestGetObject_MidBodyReadError(t *testing.T) {
+	boom := errors.New("connection reset by peer")
+	hc := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Status:        "200 OK",
+			Header:        http.Header{},
+			ContentLength: 64,
+			Body: io.NopCloser(io.MultiReader(
+				bytes.NewReader([]byte("1234567890")),
+				errReader{boom},
+			)),
+			Request: r,
+		}, nil
+	})}
+	c := client.New("http://coordinator.invalid", client.WithHTTPClient(hc))
+
+	data, err := c.GetObject(context.Background(), "partial.bin")
+	if err == nil {
+		t.Fatalf("expected an error, got nil with %d bytes", len(data))
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error should wrap the read failure; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "after 10 bytes") {
+		t.Errorf("error should report how far the read got; got %v", err)
+	}
+	if data != nil {
+		t.Errorf("expected nil data, got %d bytes", len(data))
+	}
+}
+
+// TestGetObject_NoContentLength_ShortBodyUndetected documents the limit of the
+// fix rather than asserting a guarantee it does not make.  With no
+// Content-Length there is nothing to compare against and a close-delimited
+// short body is indistinguishable from a complete one, so it still succeeds.
+// The coordinator always sets Content-Length on GET /api/v1/objects, so this is
+// not reachable against a GlobalFS server; the test exists so that a future
+// change to a streaming or chunked response path fails here and is forced to
+// think about end-to-end integrity instead.
+func TestGetObject_NoContentLength_ShortBodyUndetected(t *testing.T) {
+	c := rawServer(t, "HTTP/1.0 200 OK\r\nContent-Type: application/octet-stream\r\n\r\n12345678")
+
+	data, err := c.GetObject(context.Background(), "unlengthed.bin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "12345678" {
+		t.Errorf("got %q, want 12345678", data)
+	}
+}
+
+// TestGetObject_ExactContentLength verifies the check does not reject a
+// correct, complete response.
+func TestGetObject_ExactContentLength(t *testing.T) {
+	payload := bytes.Repeat([]byte("ACGT"), 4096) // 16 KiB
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusOK)
+		w.Write(payload)
+	})
+	c := newServer(t, mux)
+
+	data, err := c.GetObject(context.Background(), "data/genome.bam")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Errorf("got %d bytes, want %d", len(data), len(payload))
+	}
+}
+
+// TestGetObject_EmptyObject verifies a zero-length object with
+// Content-Length: 0 is not mistaken for a truncation.
+func TestGetObject_EmptyObject(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+	})
+	c := newServer(t, mux)
+
+	data, err := c.GetObject(context.Background(), "empty")
+	if err != nil {
+		t.Fatalf("GetObject on an empty object: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("got %d bytes, want 0", len(data))
+	}
+}
+
+// TestGetObject_ServerWriteTimeout reproduces the field scenario from #74
+// end-to-end: a real coordinator-shaped handler writes a large body with
+// Content-Length set, the server's WriteTimeout fires mid-write, and the client
+// must not report success.
+func TestGetObject_ServerWriteTimeout(t *testing.T) {
+	const size = 8 << 20
+	payload := make([]byte, size)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		WriteTimeout: 150 * time.Millisecond,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusOK)
+			w.Write(payload) // fails partway once WriteTimeout fires
+		}),
+	}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+
+	// Throttle the client's reads so the server's write deadline expires while
+	// the body is still in flight.
+	hc := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return &slowConn{Conn: conn}, nil
+		},
+	}}
+	c := client.New("http://"+ln.Addr().String(), client.WithHTTPClient(hc))
+
+	data, err := c.GetObject(context.Background(), "big.bin")
+	if err == nil {
+		t.Fatalf("expected an error for a server-truncated body, got nil with %d of %d bytes",
+			len(data), size)
+	}
+	if data != nil {
+		t.Errorf("partial data must not be returned; got %d bytes", len(data))
+	}
+}
+
+// roundTripperFunc adapts a function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// errReader always fails, standing in for a connection that drops mid-body.
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+// slowConn reads in small, slow increments so a server-side write deadline has
+// time to expire while the response body is still being drained.
+type slowConn struct {
+	net.Conn
+}
+
+func (s *slowConn) Read(b []byte) (int, error) {
+	if len(b) > 4096 {
+		b = b[:4096]
+	}
+	time.Sleep(2 * time.Millisecond)
+	return s.Conn.Read(b)
 }
 
 // ── PutObject ─────────────────────────────────────────────────────────────────

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -439,17 +439,19 @@ func rawServer(t *testing.T, response string) *client.Client {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	t.Cleanup(func() { ln.Close() })
+	t.Cleanup(func() { _ = ln.Close() })
 	go func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
 				return
 			}
-			// Consume the request head; we do not care what it says.
-			conn.Read(make([]byte, 4096))
-			conn.Write([]byte(response))
-			conn.Close()
+			// Consume the request head; we do not care what it says.  Every
+			// error here is ignored on purpose: the client is the subject of the
+			// test, and a failure on this side surfaces as a client-side error.
+			_, _ = conn.Read(make([]byte, 4096))
+			_, _ = conn.Write([]byte(response))
+			_ = conn.Close()
 		}
 	}()
 	return client.New("http://" + ln.Addr().String())
@@ -569,7 +571,7 @@ func TestGetObject_ExactContentLength(t *testing.T) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
 		w.WriteHeader(http.StatusOK)
-		w.Write(payload)
+		_, _ = w.Write(payload)
 	})
 	c := newServer(t, mux)
 
@@ -620,11 +622,13 @@ func TestGetObject_ServerWriteTimeout(t *testing.T) {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
 			w.WriteHeader(http.StatusOK)
-			w.Write(payload) // fails partway once WriteTimeout fires
+			// The error is expected — WriteTimeout fires partway through — and
+			// is asserted on the client side, which is the subject here.
+			_, _ = w.Write(payload)
 		}),
 	}
-	go srv.Serve(ln)
-	t.Cleanup(func() { srv.Close() })
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
 
 	// Throttle the client's reads so the server's write deadline expires while
 	// the body is still in flight.


### PR DESCRIPTION
Two critical v0.2.2 fixes, one commit each. Both are data/availability bugs where the failure was silent or fatal rather than reported.

Touches only `internal/replication/worker.{go,_test.go}` and `pkg/client/client.{go,_test.go}`.

---

## #72 — `Checksum[:8]` panicked and took the coordinator with it

`internal/replication/worker.go:253` sliced the source checksum to 8 characters for a log line. The guard above establishes only `Checksum != ""`. Reproduced against the pre-fix tree:

```
panic: runtime error: slice bounds out of range [:8] with length 2
```

The checksum comes from S3 user metadata, so 64 hex characters is a convention, not an invariant. Replaced with a `shortChecksum` helper that returns the input unchanged at 8 bytes or fewer. It is the only `[:8]` in the repository.

### The recover() question

The slice is the smaller half. There was no `recover()` in the worker or in the coordinator hosting it, so this panic did not fail a job — it terminated `globalfs-coordinator`. The job is persisted and re-enqueued at startup, so the process would die again on every restart until somebody found a two-character string in object metadata.

I considered not recovering. The argument against is real: recover turns a crash into a warning, and a crash is the honest signal that an invariant broke. But recovering is right here, for reasons specific to this code:

- **The unit of work is one object, and it is already fallible.** `processJob` has a retry loop and an `EventFailed` terminal state — there is an existing, correct way to say "this job did not work." Letting a panic reach the top of the goroutine converts a per-object failure into a per-process one, which is a strictly worse mapping of blast radius to cause.
- **`transfer` holds no state to corrupt.** It is a pure GET → PUT with no locks held and nothing partially mutated in the worker. There is no invariant that survival could carry forward, which is the usual reason to prefer dying.
- **The input is attacker-influenced.** Object metadata arrives from a remote store. "Any object can stop the daemon" is a denial-of-service, and care at individual index expressions does not make that class unreachable.
- **The alternative is not "crash loudly," it is "crash silently."** The panic goes to a stderr nobody is tailing, on a process that is no longer running. A recovered panic logs at Error with the key, both site names, the panic value and the full stack — and the coordinator stays up to serve it.

Containment, not suppression. Two layers, not redundant:

- **`safeTransfer`** wraps the transfer call and converts a panic into an ordinary attempt error, so the existing retry/backoff/`EventFailed` machinery handles it. The job is retried twice more against the same bad input — an accepted cost; three log lines beat one crash, and pattern-matching a panic value to decide retryability would be worse than the disease.
- **`runJob`** wraps `processJob` as a last resort, covering the retry loop, the log calls that dereference job fields, and `emit`. It **emits `EventFailed` before returning** — not for tidiness: `drainWorkerEvents` deletes a persisted job from the metadata store only on a terminal event, so a silent recover would strand the job and re-enqueue it on every restart. The crash loop again, minus the crash.

### Tests (4 new, all verified failing pre-fix)

| Test | Pre-fix behaviour |
|---|---|
| `TestShortChecksum` | panics on the empty input |
| `TestTransfer_ShortMatchingChecksum_DoesNotPanic` | `slice bounds out of range [:8] with length 2` |
| `TestWorker_ShortMatchingChecksum_WorkerSurvives` | **kills the test binary** |
| `TestWorker_PanicInTransfer_FailsJobAndKeepsWorkerAlive` | **kills the test binary** |

The last two are the point: pre-fix they do not report a failure, they take the process down — exactly what happens to the coordinator in production. Both then enqueue a second job and assert it completes on the same worker goroutine, so the test distinguishes "did not crash" from "still works."

---

## #74 — `GetObject` returned truncated data as success

`pkg/client/client.go:273` was `return io.ReadAll(resp.Body)`. Every caller treats non-nil `data` as authoritative, including `object get`, which returns early only on `err` and otherwise writes `data` and prints "N bytes". A body that stopped partway produced a short file and exit 0.

Now: the read error is wrapped (with how far the read got and the key) and the partial bytes are **discarded**; then the length is cross-checked against `Content-Length`. Returning `nil` rather than the partial slice is deliberate — `(partialData, err)` is the shape that caused this bug.

### A correction to the issue's diagnosis

The issue attributes the silence to `io.ReadAll` swallowing the failure. **It does not.** I reproduced the described scenario exactly — 8 MiB body, `Content-Length` set, `http.Server` with a `WriteTimeout` firing mid-write, throttled client reader:

```
server write err: write tcp ...: i/o timeout
status=200 ContentLength=8388608 got=1025999 want=8388608 readErr=unexpected EOF
```

`io.ReadAll` returned `io.ErrUnexpectedEOF`. net/http's body reader knows the declared length and reports the shortfall itself. The error was always there; the defect is that the signature let it travel next to usable bytes, and the CLI — having checked `err` and moved on — wrote them out.

That is a smaller mechanism than the issue describes and a more dangerous one: the information needed to prevent the corruption was in hand at every layer and was discarded by the shape of the API. **The severity assessment stands**; only the mechanism differs, and it changes what the fix has to be — the error check alone closes the reported case, which is why it comes first.

I mapped what the transport does and does not catch, using hand-written raw responses:

| response | `ContentLength` | `len(data)` | `readErr` |
|---|---|---|---|
| `Content-Length` short | 64 | 8 | `unexpected EOF` |
| chunked, framing truncated | -1 | 8 | `unexpected EOF` |
| chunked, early `0` terminator | -1 | 8 | **`<nil>`** |
| HTTP/1.0 close-delimited | -1 | 8 | **`<nil>`** |

So the length check is not what catches the reported bug. It is kept for two narrower reasons: `WithHTTPClient` is public API, so any RoundTripper can be substituted and a check independent of which one is installed is worth two lines; and it converts a class of bug from silent to loud while the object is still identifiable by key.

The two `<nil>` rows are honestly undetectable here — with no declared length a short close-delimited body is byte-for-byte what a complete short object looks like. `TestGetObject_NoContentLength_ShortBodyUndetected` asserts that current behaviour rather than pretending otherwise, so a future move to a chunked/streaming response path fails a test and has to confront end-to-end integrity (a checksum) instead of assuming this fix covers it. The coordinator sets `Content-Length` unconditionally on `GET /api/v1/objects` today, so the check is live against a real server.

### The other two ReadAlls (lines 241, 443)

Left as-is, with comments recording why. Both read *error* bodies for human-readable detail; the answer they compute comes from the status code, already in hand. A truncated read there degrades a message — it cannot manufacture a false success, and losing the status code because the explanatory body failed to read would be worse. They are unbounded, which is real and is **#111's**; not touched here.

### Tests (6 new, 4 verified failing pre-fix)

| Test | Pre-fix behaviour |
|---|---|
| `ShortBody_ContentLength` | returned 8 partial bytes; error did not name the key |
| `ShortBody_NoTransportError` | `expected an error, got nil with 8 bytes` |
| `MidBodyReadError` | `expected nil data, got 10 bytes` |
| `ServerWriteTimeout` | `partial data must not be returned; got 1041863 bytes` |

`ServerWriteTimeout` is the field reproduction: real `http.Server` with a `WriteTimeout`, real socket, throttled dialer, 1.04 MB of an 8 MiB object handed back as success before the fix.

`ExactContentLength` (16 KiB) and `EmptyObject` (`Content-Length: 0`) pass before and after — they prove the new check rejects nothing legitimate. A zero-length object is the case an `if resp.ContentLength > 0` guard would have gotten wrong.

---

## Verification

```
go build ./...              clean
go vet ./...                clean
gofmt -l .                  empty
go test -race -timeout=5m ./...   all 15 packages ok
```

Each new test was verified to fail with the corresponding fix temporarily reverted (`git stash` on the production file only), then restored. For #72 that required a temporary shim providing the old `shortChecksum` body so the tests compiled against the pre-fix worker; the shim was deleted before committing.

## Not done

- **#111** (unbounded reads in `pkg/client`) — out of scope, deliberately untouched.
- **`CHANGELOG.md`** — left to the maintainer.
- **The `object get` caller in `cmd/globalfs/main.go`** — see the boundary note below. It needed no change: it already returns on a non-nil error, and the fix makes that check sufficient.

## Boundary

`cmd/globalfs/main.go` is owned by another agent, so I did not touch it. I traced the call path and confirmed no change is needed there: `buildObjectGetCmd` does `if err != nil { return err }` before writing, so once `GetObject` stops returning `(partialData, nil)` the CLI is correct. The fix belongs in the client regardless — every caller, including third-party SDK users, inherits it.
