### PR TITLE
fix: v0.2.2 API and server-config issues (#73, #75, #76, #81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,18 @@ Responses are `application/json`. Error responses have the shape:
 {"error": "message"}
 ```
 
+### Object key restrictions
+
+Request paths containing a `..` component are rejected with `400`, in both their
+literal and percent-encoded spellings (`..`, `%2E%2E`, `%2e.`, `%2F%2E%2E%2F`).
+The check runs before routing, so a traversal is never redirected onto another
+endpoint — relevant if you authorize by path prefix at a proxy.
+
+`..` is only rejected as a whole path component. Keys such as `a..b`,
+`snapshot..`, and `v1..2/file.bam` are accepted and stored verbatim. S3 permits
+a bare `..` component, so a key of that form cannot be addressed through this
+API.
+
 ### Health endpoints
 
 #### `GET /healthz`

--- a/README.md
+++ b/README.md
@@ -276,6 +276,39 @@ Put and Delete invalidate the affected key so stale data is never returned.
 | `transfer_chunk_size` | int | `16777216` | Transfer chunk size in bytes (16 MiB) |
 | `cache_size` | string | `1GB` | Passed to ObjectFS (informational) |
 
+### `security`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allow_private_endpoints` | bool | `false` | Permit API-supplied `s3_endpoint` values that resolve into private address space |
+| `allowed_endpoint_hosts` | []string | _(empty)_ | Exact-match hosts exempt from endpoint address checks |
+
+These apply only to `s3_endpoint` in `POST /api/v1/sites`, not to the `sites:`
+block of a config file — a config file is operator input, the API is not.
+
+`POST /api/v1/sites` makes the coordinator sign a `HeadBucket` to the endpoint
+with its own AWS credentials, so an unconstrained endpoint would hand a valid
+SigV4 `Authorization` header to any host a caller names. Endpoints must be
+absolute `http`/`https` origins, and are rejected if they resolve to loopback,
+link-local (including IMDS at `169.254.169.254`), unspecified, or multicast
+addresses — checked after DNS resolution, so a public name pointing at an
+internal address is caught too.
+
+Set `allow_private_endpoints: true` for in-cluster MinIO on an RFC1918 address.
+It does **not** unblock loopback or link-local; use `allowed_endpoint_hosts` for
+those:
+
+```yaml
+security:
+  allow_private_endpoints: true
+  allowed_endpoint_hosts:
+    - minio.storage.svc.cluster.local
+```
+
+Known gap: the interval between resolving the host and the S3 SDK connecting is
+a DNS-rebinding window. Closing it requires pinning the connection to the
+resolved address, which the ObjectFS SDK does not currently expose.
+
 ---
 
 ## CLI Reference
@@ -541,6 +574,12 @@ Register a new site. Returns `201 Created`.
   "s3_endpoint": ""
 }
 ```
+
+`s3_endpoint` is optional; empty means the AWS default for the region. When
+supplied it must be an absolute `http`/`https` origin (no userinfo, path, query,
+or fragment) that does not resolve into a blocked address range — see
+[`security`](#security). Rejected endpoints return `400`; a reachability failure
+returns `502` with a generic message, the detail going to the coordinator log.
 
 #### `DELETE /api/v1/sites/{name}`
 

--- a/cmd/coordinator/api.go
+++ b/cmd/coordinator/api.go
@@ -358,8 +358,8 @@ func isDisallowedAddr(ip net.IP, allowPrivate bool) (bool, string) {
 // signs a request to it.  An empty endpoint means "use the AWS default" and is
 // always allowed.
 //
-// It returns errEndpointRejected for the caller and a detailed reason for the
-// log.  Requirements:
+// It returns a detailed reason for the log and errEndpointRejected for the
+// caller; reason is "" exactly when err is nil.  Requirements:
 //
 //   - absolute URL with an http or https scheme and a host;
 //   - no userinfo, and no path/query/fragment beyond "/" (an S3 endpoint is an
@@ -378,43 +378,43 @@ func isDisallowedAddr(ip net.IP, allowPrivate bool) (bool, string) {
 // transport option).  So this narrows the attack from "any host by name" to "a
 // host whose DNS flips between two answers inside one HeadBucket", and the rest
 // belongs upstream.
-func validateS3Endpoint(ctx context.Context, endpoint string, sec config.SecurityConfig, resolve endpointResolver) (error, string) {
+func validateS3Endpoint(ctx context.Context, endpoint string, sec config.SecurityConfig, resolve endpointResolver) (reason string, err error) {
 	if endpoint == "" {
-		return nil, ""
+		return "", nil
 	}
 
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return errEndpointRejected, fmt.Sprintf("unparseable URL: %v", err)
+		return fmt.Sprintf("unparseable URL: %v", err), errEndpointRejected
 	}
 	switch u.Scheme {
 	case "http", "https":
 	default:
-		return errEndpointRejected, fmt.Sprintf("scheme %q is not http or https", u.Scheme)
+		return fmt.Sprintf("scheme %q is not http or https", u.Scheme), errEndpointRejected
 	}
 	if u.Host == "" {
-		return errEndpointRejected, "URL has no host"
+		return "URL has no host", errEndpointRejected
 	}
 	if u.User != nil {
-		return errEndpointRejected, "URL must not contain userinfo"
+		return "URL must not contain userinfo", errEndpointRejected
 	}
 	if u.Path != "" && u.Path != "/" {
-		return errEndpointRejected, fmt.Sprintf("URL must not contain a path (got %q)", u.Path)
+		return fmt.Sprintf("URL must not contain a path (got %q)", u.Path), errEndpointRejected
 	}
 	if u.RawQuery != "" || u.Fragment != "" {
-		return errEndpointRejected, "URL must not contain a query or fragment"
+		return "URL must not contain a query or fragment", errEndpointRejected
 	}
 
 	host := u.Hostname()
 	if host == "" {
-		return errEndpointRejected, "URL has no host"
+		return "URL has no host", errEndpointRejected
 	}
 
 	// Exact-match allowlist: the narrow escape hatch, and the only way to permit
 	// a loopback endpoint (LocalStack in a test harness, say).
 	for _, allowed := range sec.AllowedEndpointHosts {
 		if strings.EqualFold(strings.TrimSpace(allowed), host) {
-			return nil, ""
+			return "", nil
 		}
 	}
 
@@ -422,24 +422,24 @@ func validateS3Endpoint(ctx context.Context, endpoint string, sec config.Securit
 	// rejected without a DNS round trip.
 	if ip := net.ParseIP(host); ip != nil {
 		if bad, reason := isDisallowedAddr(ip, sec.AllowPrivateEndpoints); bad {
-			return errEndpointRejected, reason
+			return reason, errEndpointRejected
 		}
-		return nil, ""
+		return "", nil
 	}
 
 	addrs, err := resolve(ctx, host)
 	if err != nil {
-		return errEndpointRejected, fmt.Sprintf("host does not resolve: %v", err)
+		return fmt.Sprintf("host does not resolve: %v", err), errEndpointRejected
 	}
 	if len(addrs) == 0 {
-		return errEndpointRejected, "host resolves to no addresses"
+		return "host resolves to no addresses", errEndpointRejected
 	}
 	for _, a := range addrs {
 		if bad, reason := isDisallowedAddr(a.IP, sec.AllowPrivateEndpoints); bad {
-			return errEndpointRejected, fmt.Sprintf("resolves to %s: %s", a.IP, reason)
+			return fmt.Sprintf("resolves to %s: %s", a.IP, reason), errEndpointRejected
 		}
 	}
-	return nil, ""
+	return "", nil
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -499,7 +499,7 @@ func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator, sec c
 		connectCtx, cancel := context.WithTimeout(daemonCtx, 30*time.Second)
 		defer cancel()
 
-		if err, reason := validateS3Endpoint(connectCtx, req.S3Endpoint, sec, defaultEndpointResolver); err != nil {
+		if reason, err := validateS3Endpoint(connectCtx, req.S3Endpoint, sec, defaultEndpointResolver); err != nil {
 			// The reason is logged, never returned: see errEndpointRejected.
 			slog.Warn("api: add site: endpoint rejected",
 				"name", req.Name,
@@ -1035,7 +1035,7 @@ func withObjectMetrics(operation string, m *metrics.Metrics, next http.HandlerFu
 // This lives here rather than inline in main so tests can exercise the same
 // chain the daemon serves instead of a hand-assembled approximation.
 func buildHandler(mux *http.ServeMux, apiKey string) http.Handler {
-	var handler http.Handler = rejectUnsafePath(mux)
+	handler := rejectUnsafePath(mux)
 	if apiKey != "" {
 		handler = apiKeyMiddleware(apiKey)(handler)
 	}

--- a/cmd/coordinator/api.go
+++ b/cmd/coordinator/api.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -52,6 +53,14 @@ const maxJSONBodyBytes = 1 << 20 // 1 MiB
 
 // validateObjectKey returns an error if key contains path-traversal characters
 // (null bytes or ".." components) that could bypass bucket prefix boundaries.
+//
+// This is the second of two layers and it is not the load-bearing one.  It runs
+// inside the handler, on the key http.ServeMux has already extracted, and by
+// then the mux has path-cleaned the request — a literal ".." never reaches here
+// at all (see rejectUnsafePath for what does).  Keep it: it still catches a
+// traversal that arrives through the decoding of an escaped separator
+// ("%2F%2E%2E%2F" reaches the handler as key "/../sites/..."), and it guards
+// callers that invoke the handlers directly rather than through the mux.
 func validateObjectKey(key string) error {
 	if strings.Contains(key, "\x00") {
 		return fmt.Errorf("key contains null byte")
@@ -62,6 +71,94 @@ func validateObjectKey(key string) error {
 		}
 	}
 	return nil
+}
+
+// ── Path traversal guard ──────────────────────────────────────────────────────
+
+// hasUnsafePathSegment reports whether escapedPath contains a ".." path
+// component or a null byte, considering both the literal and the
+// percent-encoded spelling of each.
+//
+// It takes the *escaped* path (r.URL.EscapedPath()) rather than r.URL.Path,
+// because r.URL.Path is already percent-decoded: "%2E%2E" and ".." are
+// indistinguishable there, and only one of the two survives the mux.  Each
+// segment is unescaped exactly once and then re-split on "/", so an encoded
+// separator ("%2F%2E%2E%2F") is caught as well.
+//
+// Decoding once and no more is deliberate.  A key containing a literal "%2E"
+// is legal in S3 and arrives as "%252E"; unescaping twice would reject it.
+func hasUnsafePathSegment(escapedPath string) bool {
+	for _, seg := range strings.Split(escapedPath, "/") {
+		// Fast path: no escaping to consider.
+		if !strings.Contains(seg, "%") {
+			if seg == ".." {
+				return true
+			}
+			continue
+		}
+		dec, err := url.PathUnescape(seg)
+		if err != nil {
+			// Malformed percent-encoding.  net/http normally rejects this before
+			// a handler runs; treat it as hostile rather than guessing.
+			return true
+		}
+		if strings.Contains(dec, "\x00") {
+			return true
+		}
+		for _, part := range strings.Split(dec, "/") {
+			if part == ".." {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// rejectUnsafePath rejects requests whose raw path contains a ".." component
+// before http.ServeMux can dispatch them.
+//
+// This has to be middleware; it cannot live in a handler.  ServeMux path-cleans
+// the target and answers with a 307 *before* it picks a handler, so
+// validateObjectKey never sees a literal "..":
+//
+//	DELETE /api/v1/objects/../sites/primary        -> 307 Location=/api/v1/sites/primary
+//	DELETE /api/v1/objects/a/b/../../../sites/x    -> 307 Location=/api/v1/sites/x
+//	DELETE /api/v1/objects/data/..                 -> 307 Location=/api/v1/objects/
+//
+// Go's http.Client replays both the method and the X-GlobalFS-API-Key header on
+// a 307, so pkg/client following that first redirect turns an object-scoped
+// DELETE into a site deregistration and reports success (#73).  A reverse proxy
+// that allows /api/v1/objects/ and denies /api/v1/sites/ is bypassed the same
+// way, because the proxy only ever sees the object path.
+//
+// Rejecting rather than cleaning is the point.  Cleaning would keep the third
+// case above silently succeeding as a delete of a different key, and "data/.."
+// is a legal S3 key this server cannot route — 400 says so, a 307 does not.
+//
+// The guard applies to every path, not just /api/v1/objects/: no route this
+// server exposes has a legitimate ".." component, and confining it to one
+// prefix would mean deciding which prefix *after* the mux had already decided
+// for us.
+func rejectUnsafePath(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hasUnsafePathSegment(r.URL.EscapedPath()) {
+			slog.Warn("api: rejected request with unsafe path",
+				"method", r.Method,
+				"raw_path", r.URL.EscapedPath(),
+				"request_id", requestIDFromCtx(r.Context()),
+				"remote_addr", r.RemoteAddr,
+			)
+			if r.Method == http.MethodHead {
+				// HEAD must not return a body.
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeError(w, http.StatusBadRequest,
+				"invalid request path: path traversal component not permitted")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // ── API key middleware ────────────────────────────────────────────────────────
@@ -615,6 +712,32 @@ func withObjectMetrics(operation string, m *metrics.Metrics, next http.HandlerFu
 		}
 		m.RecordOperation(operation, status, time.Since(start))
 	}
+}
+
+// buildHandler wraps mux in the server's middleware chain, applied innermost →
+// outermost:
+//
+//	mux → rejectUnsafePath → apiKey (when key != "") → logging → requestID
+//
+// requestID is outermost so every response carries a correlation ID; logging
+// wraps apiKey so auth rejections are recorded too.  When key is "" the auth
+// layer is omitted entirely.
+//
+// The order of the two innermost layers is load-bearing. rejectUnsafePath must
+// wrap the mux directly — it is the only layer that observes the request target
+// before ServeMux path-cleans it and 307s a traversal onto a different route
+// (#73) — and it must sit inside apiKey so an unauthenticated traversal probe
+// gets 401, not the 400 that would confirm the path was parsed.
+//
+// This lives here rather than inline in main so tests can exercise the same
+// chain the daemon serves instead of a hand-assembled approximation.
+func buildHandler(mux *http.ServeMux, apiKey string) http.Handler {
+	var handler http.Handler = rejectUnsafePath(mux)
+	if apiKey != "" {
+		handler = apiKeyMiddleware(apiKey)(handler)
+	}
+	handler = loggingMiddleware(handler)
+	return requestIDMiddleware(handler)
 }
 
 // registerAPIRoutes registers all /api/v1/* endpoints on mux.

--- a/cmd/coordinator/api.go
+++ b/cmd/coordinator/api.go
@@ -679,6 +679,97 @@ func objectListHandler(c *coordinator.Coordinator) http.HandlerFunc {
 	}
 }
 
+// ── Per-request transfer deadlines ────────────────────────────────────────────
+//
+// http.Server's ReadTimeout and WriteTimeout are absolute deadlines on the whole
+// request and the whole response — not idle timeouts.  The values in
+// cmd/coordinator/main.go are right for a JSON control API and wrong for the
+// object routes that share the same server, and the arithmetic is not close
+// (#75):
+//
+//	WriteTimeout 10s vs a 64 MiB GET  -> truncated mid-body at ~42 MB
+//	ReadTimeout  10s vs a 256 MiB PUT -> needs 25.6 MiB/s sustained to
+//	                                     even reach the advertised cap
+//
+// So the strict server-wide deadlines stay, and the object handlers replace them
+// per request with a budget derived from the payload size and a floor.  A stalled
+// transfer is still cut off — the point is to size the deadline to the work, not
+// to remove it.
+
+// minTransferThroughputBytesPerSec is the slowest transfer rate the object routes
+// will tolerate.  A deadline is computed as size/rate, so this is what decides
+// whether a large transfer gets time to finish.
+//
+// 1 MiB/s is deliberately near the floor of plausible: it gives the documented
+// 256 MiB cap 256s and makes the advertised limit reachable, which is the defect
+// the issue identifies. Raising it re-breaks slow clients; the timeout and the
+// size cap have to be consistent with each other, and that is the constraint
+// that sets this number rather than taste.
+const minTransferThroughputBytesPerSec = 1 << 20 // 1 MiB/s
+
+// minTransferDeadline is the floor applied to every computed budget, so a small
+// object is not held to an unreasonably tight deadline (a 4 KiB object would
+// otherwise get 4ms) and a zero-length one still gets time to be written.
+const minTransferDeadline = 30 * time.Second
+
+// maxTransferDeadline caps the budget regardless of size.  Slowloris protection
+// is the reason there is a ceiling at all: without one, a caller advertising a
+// large Content-Length could hold a connection indefinitely.  256 MiB at 1 MiB/s
+// is 256s, so this leaves headroom over the documented cap without being open
+// ended.
+const maxTransferDeadline = 10 * time.Minute
+
+// transferDeadline returns the time budget for moving n bytes: n at
+// minTransferThroughputBytesPerSec, clamped to
+// [minTransferDeadline, maxTransferDeadline].
+//
+// A negative or unknown size (Content-Length of -1 on a chunked upload) yields
+// the floor.
+func transferDeadline(n int64) time.Duration {
+	if n <= 0 {
+		return minTransferDeadline
+	}
+	d := time.Duration(n/minTransferThroughputBytesPerSec) * time.Second
+	if d < minTransferDeadline {
+		return minTransferDeadline
+	}
+	if d > maxTransferDeadline {
+		return maxTransferDeadline
+	}
+	return d
+}
+
+// extendWriteDeadline replaces the server-wide WriteTimeout for this response
+// with a budget sized for n bytes.  Returns the deadline applied, or 0 if the
+// ResponseWriter does not support deadline control.
+//
+// http.ErrNotSupported is not an error worth logging loudly: httptest.Recorder
+// returns it, and so does any ResponseWriter wrapper that does not implement
+// Unwrap. The handler proceeds under the server-wide deadline in that case,
+// which is the pre-fix behaviour rather than a regression.
+func extendWriteDeadline(w http.ResponseWriter, n int64) time.Duration {
+	d := transferDeadline(n)
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(d)); err != nil {
+		if !errors.Is(err, http.ErrNotSupported) {
+			slog.Warn("api: set write deadline", "error", err)
+		}
+		return 0
+	}
+	return d
+}
+
+// extendReadDeadline does the same for a request body of n bytes.
+func extendReadDeadline(w http.ResponseWriter, n int64) time.Duration {
+	d := transferDeadline(n)
+	if err := http.NewResponseController(w).SetReadDeadline(time.Now().Add(d)); err != nil {
+		if !errors.Is(err, http.ErrNotSupported) {
+			slog.Warn("api: set read deadline", "error", err)
+		}
+		return 0
+	}
+	return d
+}
+
 // objectGetHandler handles GET /api/v1/objects/{key...} — retrieve object data.
 func objectGetHandler(c *coordinator.Coordinator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -698,11 +789,24 @@ func objectGetHandler(c *coordinator.Coordinator) http.HandlerFunc {
 			return
 		}
 
+		// The exact response size is known here, so the deadline is sized to it
+		// before a byte is written. Under the server-wide WriteTimeout of 10s any
+		// object needing longer than that was truncated mid-body, after a 200 and
+		// an accurate Content-Length had already been sent (#75).
+		extendWriteDeadline(w, int64(len(data)))
+
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write(data); err != nil {
-			slog.Warn("api: write response body", "key", key, "error", err)
+			// Nothing can be done for the client — the status and Content-Length
+			// are already committed — but this must not be swallowed: it is the
+			// only record that the response the client received was short.
+			slog.Warn("api: write response body truncated",
+				"key", key,
+				"bytes_expected", len(data),
+				"request_id", requestIDFromCtx(r.Context()),
+				"error", err)
 		}
 	}
 }
@@ -719,6 +823,28 @@ func objectPutHandler(c *coordinator.Coordinator) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "invalid object key: "+err.Error())
 			return
 		}
+
+		// Size the read deadline from the advertised body length before reading.
+		// Content-Length is untrusted, but it is only used to grant time, and the
+		// grant is bounded by maxTransferDeadline and the MaxBytesReader below —
+		// so overstating it buys a slow-loris no more than maxTransferDeadline,
+		// which is the ceiling regardless. A chunked upload reports -1 and gets
+		// the floor.
+		//
+		// Without this, ReadTimeout of 10s against the documented 256 MiB cap
+		// required 25.6 MiB/s sustained for the limit to be reachable at all: an
+		// 8 MiB upload at 2 MiB/s failed after 229 KB (#75).
+		extendReadDeadline(w, r.ContentLength)
+
+		// The *write* deadline has to be extended here too, which is not obvious.
+		// net/http arms both deadlines when it finishes reading the request
+		// headers, so WriteTimeout is already ticking while the body is still
+		// arriving. A body that takes longer than WriteTimeout to upload leaves no
+		// time to answer it: the response write fails, the connection is closed,
+		// and the client sees EOF rather than the 201 its upload earned. Found by
+		// TestObjectPut_SlowUploadNotCutOff, which failed exactly that way with
+		// only the read deadline extended.
+		extendWriteDeadline(w, r.ContentLength)
 
 		r.Body = http.MaxBytesReader(w, r.Body, maxObjectBodyBytes)
 		data, err := io.ReadAll(r.Body)
@@ -860,6 +986,17 @@ func (sr *statusRecorder) WriteHeader(code int) {
 	sr.code = code
 	sr.ResponseWriter.WriteHeader(code)
 }
+
+// Unwrap exposes the underlying ResponseWriter to http.ResponseController.
+//
+// This is required, not cosmetic. Both loggingMiddleware and withObjectMetrics
+// wrap the writer in a statusRecorder, and ResponseController walks Unwrap to
+// find something implementing SetWriteDeadline. Without this method every object
+// handler's deadline call returns http.ErrNotSupported and silently does nothing
+// — the handler keeps the server-wide 10s deadline and #75 is unfixed while
+// looking fixed. Verified: with the method absent, SetWriteDeadline through a
+// statusRecorder returns "feature not supported"; with it, nil.
+func (sr *statusRecorder) Unwrap() http.ResponseWriter { return sr.ResponseWriter }
 
 // withObjectMetrics wraps a handler to record operation duration and status.
 // m may be nil; when nil the handler is called without instrumentation.

--- a/cmd/coordinator/api.go
+++ b/cmd/coordinator/api.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -300,6 +301,147 @@ func decodeJSON(r *http.Request, dst any) error {
 	return dec.Decode(dst)
 }
 
+// ── S3 endpoint validation (SSRF guard) ───────────────────────────────────────
+
+// errEndpointRejected is the generic error returned to the caller when an
+// endpoint fails validation, replacing the transport error the handler used to
+// echo back.  The detail goes to the log instead: a 502 body containing
+// `malformed HTTP response "SSH-2.0-OpenSSH_9.6"` versus `connection refused`
+// distinguishes an open port from a closed one, which turns this endpoint into a
+// port scanner with an oracle (#76).
+var errEndpointRejected = errors.New("s3_endpoint is not permitted")
+
+// endpointResolver is the hook validateS3Endpoint uses to resolve a host to
+// addresses.  Overridable so tests can exercise the DNS-name-to-internal-address
+// case without depending on a resolver that returns a particular answer.
+type endpointResolver func(ctx context.Context, host string) ([]net.IPAddr, error)
+
+// defaultEndpointResolver resolves via the system resolver.
+func defaultEndpointResolver(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(ctx, host)
+}
+
+// isDisallowedAddr reports whether ip is in an address class a caller-supplied
+// S3 endpoint must not reach, and returns a short reason for the log.
+//
+// allowPrivate relaxes only the private classes (RFC1918, unique-local, CGNAT).
+// Loopback, link-local, unspecified, and multicast stay blocked regardless:
+// 169.254.169.254 is the highest-value target in this class and nothing that
+// serves S3 legitimately lives there.
+func isDisallowedAddr(ip net.IP, allowPrivate bool) (bool, string) {
+	switch {
+	case ip.IsUnspecified():
+		return true, "unspecified address"
+	case ip.IsLoopback():
+		return true, "loopback address"
+	case ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast():
+		// Covers 169.254.0.0/16 (and so IMDS) and fe80::/10.
+		return true, "link-local address"
+	case ip.IsInterfaceLocalMulticast(), ip.IsMulticast():
+		return true, "multicast address"
+	}
+	if !allowPrivate {
+		// net.IP.IsPrivate covers RFC1918 and RFC4193 unique-local.
+		if ip.IsPrivate() {
+			return true, "private address (set security.allow_private_endpoints to permit)"
+		}
+		// RFC6598 shared address space, 100.64.0.0/10 — not covered by IsPrivate
+		// and routable to carrier-internal infrastructure.
+		if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return true, "shared address space (set security.allow_private_endpoints to permit)"
+		}
+	}
+	return false, ""
+}
+
+// validateS3Endpoint checks a caller-supplied S3 endpoint before the coordinator
+// signs a request to it.  An empty endpoint means "use the AWS default" and is
+// always allowed.
+//
+// It returns errEndpointRejected for the caller and a detailed reason for the
+// log.  Requirements:
+//
+//   - absolute URL with an http or https scheme and a host;
+//   - no userinfo, and no path/query/fragment beyond "/" (an S3 endpoint is an
+//     origin; a path here is a sign the value is being used for something else);
+//   - every address the host resolves to passes isDisallowedAddr.
+//
+// Resolution happens rather than string matching, so "imds.attacker.example"
+// pointing at 169.254.169.254 is caught too, and *all* answers must pass — one
+// public A record does not license a second private one.
+//
+// Known limitation, called out in the issue: the gap between resolving here and
+// the SDK dialling is a DNS-rebinding window.  Closing it needs the connection
+// pinned to the address checked, i.e. a DialContext hook on the HTTP client the
+// S3 backend uses — and objectfs's SDK exposes no way to supply one
+// (sdks/go/objectfs/options.go has WithEndpoint/WithRegion/WithTLS and no
+// transport option).  So this narrows the attack from "any host by name" to "a
+// host whose DNS flips between two answers inside one HeadBucket", and the rest
+// belongs upstream.
+func validateS3Endpoint(ctx context.Context, endpoint string, sec config.SecurityConfig, resolve endpointResolver) (error, string) {
+	if endpoint == "" {
+		return nil, ""
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return errEndpointRejected, fmt.Sprintf("unparseable URL: %v", err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return errEndpointRejected, fmt.Sprintf("scheme %q is not http or https", u.Scheme)
+	}
+	if u.Host == "" {
+		return errEndpointRejected, "URL has no host"
+	}
+	if u.User != nil {
+		return errEndpointRejected, "URL must not contain userinfo"
+	}
+	if u.Path != "" && u.Path != "/" {
+		return errEndpointRejected, fmt.Sprintf("URL must not contain a path (got %q)", u.Path)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return errEndpointRejected, "URL must not contain a query or fragment"
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return errEndpointRejected, "URL has no host"
+	}
+
+	// Exact-match allowlist: the narrow escape hatch, and the only way to permit
+	// a loopback endpoint (LocalStack in a test harness, say).
+	for _, allowed := range sec.AllowedEndpointHosts {
+		if strings.EqualFold(strings.TrimSpace(allowed), host) {
+			return nil, ""
+		}
+	}
+
+	// An IP literal needs no resolution; check it directly so a bad literal is
+	// rejected without a DNS round trip.
+	if ip := net.ParseIP(host); ip != nil {
+		if bad, reason := isDisallowedAddr(ip, sec.AllowPrivateEndpoints); bad {
+			return errEndpointRejected, reason
+		}
+		return nil, ""
+	}
+
+	addrs, err := resolve(ctx, host)
+	if err != nil {
+		return errEndpointRejected, fmt.Sprintf("host does not resolve: %v", err)
+	}
+	if len(addrs) == 0 {
+		return errEndpointRejected, "host resolves to no addresses"
+	}
+	for _, a := range addrs {
+		if bad, reason := isDisallowedAddr(a.IP, sec.AllowPrivateEndpoints); bad {
+			return errEndpointRejected, fmt.Sprintf("resolves to %s: %s", a.IP, reason)
+		}
+	}
+	return nil, ""
+}
+
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
 // sitesListHandler handles GET /api/v1/sites — returns all sites with health.
@@ -314,7 +456,9 @@ func sitesListHandler(c *coordinator.Coordinator) http.HandlerFunc {
 }
 
 // addSiteHandler handles POST /api/v1/sites — register a new site at runtime.
-func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator) http.HandlerFunc {
+//
+// sec constrains which s3_endpoint values are accepted; see validateS3Endpoint.
+func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator, sec config.SecurityConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxJSONBodyBytes)
 		var req addSiteRequest
@@ -348,6 +492,26 @@ func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator) http.
 			return
 		}
 
+		// Validate the endpoint before anything signs a request to it.  site
+		// .NewFromConfig performs a HeadBucket, so an unchecked endpoint means the
+		// coordinator sends its own credentials' SigV4 Authorization header to a
+		// host the caller chose (#76).
+		connectCtx, cancel := context.WithTimeout(daemonCtx, 30*time.Second)
+		defer cancel()
+
+		if err, reason := validateS3Endpoint(connectCtx, req.S3Endpoint, sec, defaultEndpointResolver); err != nil {
+			// The reason is logged, never returned: see errEndpointRejected.
+			slog.Warn("api: add site: endpoint rejected",
+				"name", req.Name,
+				"endpoint", req.S3Endpoint,
+				"reason", reason,
+				"request_id", requestIDFromCtx(r.Context()),
+				"remote_addr", r.RemoteAddr,
+			)
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
 		siteCfg := &config.SiteConfig{
 			Name: req.Name,
 			Role: req.Role,
@@ -358,13 +522,15 @@ func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator) http.
 			},
 		}
 
-		connectCtx, cancel := context.WithTimeout(daemonCtx, 30*time.Second)
-		defer cancel()
-
 		mount, err := site.NewFromConfig(connectCtx, siteCfg)
 		if err != nil {
+			// Generic message: the transport error separates an open non-HTTP port
+			// ("malformed HTTP response \"SSH-2.0-...\"") from a closed one
+			// ("connection refused"), which is a scan oracle (#76).  Detail is
+			// logged for the operator, who can see it, rather than returned to the
+			// caller, who should not.
 			slog.Warn("api: add site: connect failed", "name", req.Name, "error", err)
-			writeError(w, http.StatusBadGateway, "failed to connect to site: "+err.Error())
+			writeError(w, http.StatusBadGateway, "failed to connect to site")
 			return
 		}
 
@@ -743,9 +909,10 @@ func buildHandler(mux *http.ServeMux, apiKey string) http.Handler {
 // registerAPIRoutes registers all /api/v1/* endpoints on mux.
 // daemonCtx is the coordinator's parent context, used for S3 connection setup.
 // m may be nil; when non-nil, object handler latency and status are recorded.
-func registerAPIRoutes(mux *http.ServeMux, daemonCtx context.Context, c *coordinator.Coordinator, m *metrics.Metrics) {
+// sec constrains which s3_endpoint values POST /api/v1/sites will accept.
+func registerAPIRoutes(mux *http.ServeMux, daemonCtx context.Context, c *coordinator.Coordinator, m *metrics.Metrics, sec config.SecurityConfig) {
 	mux.HandleFunc("GET /api/v1/sites", sitesListHandler(c))
-	mux.HandleFunc("POST /api/v1/sites", addSiteHandler(daemonCtx, c))
+	mux.HandleFunc("POST /api/v1/sites", addSiteHandler(daemonCtx, c, sec))
 	mux.HandleFunc("DELETE /api/v1/sites/{name}", removeSiteHandler(c))
 	mux.HandleFunc("POST /api/v1/replicate", replicateHandler(c))
 

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -1368,6 +1368,243 @@ func TestSitesList_WithCircuitBreaker_Open(t *testing.T) {
 	}
 }
 
+// ── Path traversal guard (#73) ────────────────────────────────────────────────
+
+// makeTestServer serves the real middleware chain — buildHandler over the real
+// route table — so these tests exercise what the daemon exercises, including the
+// ServeMux path-cleaning step that is the whole subject of #73. Assembling the
+// handlers by hand, as most tests in this file do, would bypass the mux and
+// therefore bypass the bug.
+func makeTestServer(t *testing.T, objs map[string][]byte, apiKey string) (*httptest.Server, *coordinator.Coordinator, *testMemClient) {
+	t.Helper()
+	c, mc := makeTestCoordinator(t, objs)
+	mux := http.NewServeMux()
+	registerAPIRoutes(mux, context.Background(), c, nil)
+	srv := httptest.NewServer(buildHandler(mux, apiKey))
+	t.Cleanup(srv.Close)
+	return srv, c, mc
+}
+
+// noRedirectClient is an http.Client that surfaces a 3xx instead of following
+// it. Following is what makes #73 exploitable — Go's client replays the method
+// and the X-GlobalFS-API-Key header on a 307 — so a test that follows redirects
+// cannot distinguish "rejected" from "redirected, then succeeded elsewhere".
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// TestPathTraversal_RejectedNotRedirected is the core regression test for #73.
+//
+// Each hostile target must produce a 400 from the guard. Before the fix the
+// literal forms produced a 307 whose Location pointed at a *different route*,
+// which the supported client then followed with the API key attached — so
+// asserting "no Location header, and not a 3xx" is what fails on the pre-fix
+// tree, where merely asserting "not 2xx" would have passed.
+func TestPathTraversal_RejectedNotRedirected(t *testing.T) {
+	t.Parallel()
+	srv, _, _ := makeTestServer(t, map[string][]byte{"data/x": []byte("payload")}, "")
+	client := noRedirectClient()
+
+	cases := []struct {
+		name   string
+		method string
+		target string
+	}{
+		// Literal "..": the mux used to 307 these onto /api/v1/sites/*, turning
+		// an object-scoped call into a site deregistration.
+		{"literal dotdot crosses to sites", http.MethodDelete, "/api/v1/objects/../sites/primary"},
+		{"literal dotdot multi segment", http.MethodDelete, "/api/v1/objects/a/b/../../../sites/primary"},
+		{"literal dotdot on GET reads site inventory", http.MethodGet, "/api/v1/objects/../sites"},
+		{"literal dotdot on PUT", http.MethodPut, "/api/v1/objects/tenants/A/../B/owned.txt"},
+		{"literal dotdot on HEAD", http.MethodHead, "/api/v1/objects/../sites"},
+		// Trailing "..": used to 307 to /api/v1/objects/, i.e. a request for one
+		// key answered as a request for another. The issue is explicit that 400 is
+		// the wanted outcome here, not a redirect.
+		{"trailing dotdot", http.MethodDelete, "/api/v1/objects/data/.."},
+		// Encoded forms. These already reached the handler pre-fix and were caught
+		// by validateObjectKey; they must stay rejected.
+		{"encoded dotdot upper", http.MethodDelete, "/api/v1/objects/%2E%2E/sites/primary"},
+		{"encoded dotdot lower", http.MethodDelete, "/api/v1/objects/%2e%2e/sites/primary"},
+		{"mixed encoded dotdot", http.MethodDelete, "/api/v1/objects/%2e./sites/primary"},
+		{"encoded separator and dotdot", http.MethodDelete, "/api/v1/objects/%2F%2E%2E%2Fsites/primary"},
+		// Non-object routes get the same treatment; no route here has a
+		// legitimate ".." component.
+		{"traversal under sites", http.MethodDelete, "/api/v1/sites/../sites/primary"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := http.NewRequest(tc.method, srv.URL+tc.target, strings.NewReader("body"))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if loc := resp.Header.Get("Location"); loc != "" {
+				t.Errorf("%s %s: served a redirect to %q — a client that follows it "+
+					"crosses the authorization boundary (#73)", tc.method, tc.target, loc)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("%s %s: got %d, want 400", tc.method, tc.target, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestPathTraversal_DoesNotReachSiteHandlers is the impact assertion: the exact
+// call from the issue must leave the site inventory intact. Pre-fix this
+// returned 204 and removed the site.
+func TestPathTraversal_DoesNotReachSiteHandlers(t *testing.T) {
+	t.Parallel()
+	srv, c, _ := makeTestServer(t, nil, "")
+
+	if got := len(c.Sites()); got != 1 {
+		t.Fatalf("precondition: expected 1 site, got %d", got)
+	}
+
+	// A client that *does* follow redirects — pkg/client's behaviour, and the
+	// behaviour that made this exploitable.
+	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/objects/../sites/primary", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		t.Errorf("traversal returned 204 — the site deregistration succeeded (#73)")
+	}
+	if got := len(c.Sites()); got != 1 {
+		t.Errorf("site count went 1 -> %d: an object-scoped DELETE deregistered a site (#73)", got)
+	}
+}
+
+// TestPathTraversal_AuthCheckedBeforePathGuard pins the middleware order. The
+// guard sits inside apiKeyMiddleware, so an unauthenticated traversal probe must
+// be answered 401 — a 400 would confirm to an unauthenticated caller that the
+// path was parsed, and would mean the guard runs outside auth.
+func TestPathTraversal_AuthCheckedBeforePathGuard(t *testing.T) {
+	t.Parallel()
+	srv, _, _ := makeTestServer(t, nil, "s3cret")
+	client := noRedirectClient()
+
+	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/objects/../sites/primary", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated traversal: got %d, want 401", resp.StatusCode)
+	}
+
+	// With the key, the same request is rejected by the guard rather than served.
+	req2, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/objects/../sites/primary", nil)
+	req2.Header.Set(apiKeyHeader, "s3cret")
+	resp2, err := client.Do(req2)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Errorf("authenticated traversal: got %d, want 400", resp2.StatusCode)
+	}
+}
+
+// TestPathTraversal_LegitimateKeysStillWork guards against the fix over-reaching.
+// S3 keys may contain dots in every arrangement except a bare ".." component, and
+// a key holding a literal percent-encoded "%2E" (sent as "%252E") must survive:
+// unescaping twice in the guard would reject it.
+func TestPathTraversal_LegitimateKeysStillWork(t *testing.T) {
+	t.Parallel()
+	srv, _, mc := makeTestServer(t, nil, "")
+	client := noRedirectClient()
+
+	cases := []struct {
+		name    string
+		target  string
+		wantKey string
+	}{
+		{"dotdot as substring", "/api/v1/objects/a..b", "a..b"},
+		{"dotdot inside a segment", "/api/v1/objects/data/v1..2/file.bam", "data/v1..2/file.bam"},
+		{"three dots is not a traversal", "/api/v1/objects/.../file", ".../file"},
+		{"dots inside a filename", "/api/v1/objects/archive.tar.gz", "archive.tar.gz"},
+		{"dotdot suffix on a segment", "/api/v1/objects/snapshot..", "snapshot.."},
+		{"double-encoded percent survives", "/api/v1/objects/pct%252E%252E/f", "pct%2E%2E/f"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPut, srv.URL+tc.target, strings.NewReader("payload"))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusCreated {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("PUT %s: got %d (%s), want 201 — the guard rejected a legal S3 key",
+					tc.target, resp.StatusCode, strings.TrimSpace(string(body)))
+			}
+			if !mc.hasKey(tc.wantKey) {
+				t.Errorf("PUT %s: stored under some other key, want %q", tc.target, tc.wantKey)
+			}
+		})
+	}
+}
+
+// TestHasUnsafePathSegment is the unit-level table for the guard's predicate,
+// covering spellings that are awkward to drive through a live server.
+func TestHasUnsafePathSegment(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/objects/data/x", false},
+		{"/api/v1/objects/a..b", false},
+		{"/api/v1/objects/...", false},
+		{"/api/v1/objects/.", false},
+		{"/api/v1/objects/%2E", false},   // a single encoded dot is a legal key
+		{"/api/v1/objects/%2E%2E", true}, // encoded ".."
+		{"/api/v1/objects/../x", true},
+		{"/api/v1/objects/x/..", true},
+		{"..", true},
+		{"/api/v1/objects/%2e./x", true},
+		{"/api/v1/objects/.%2e/x", true},
+		{"/api/v1/objects/%2F%2E%2E%2F", true}, // encoded separator hiding a ".."
+		{"/api/v1/objects/%00", true},          // null byte
+		{"/api/v1/objects/%zz", true},          // malformed encoding: treat as hostile
+		{"/api/v1/objects/pct%252E%252E", false},
+	}
+
+	for _, tc := range cases {
+		if got := hasUnsafePathSegment(tc.path); got != tc.want {
+			t.Errorf("hasUnsafePathSegment(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
 // TestWithObjectMetrics_NilMetrics verifies that withObjectMetrics calls the
 // next handler without panicking when m is nil.
 func TestWithObjectMetrics_NilMetrics(t *testing.T) {

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -35,6 +35,12 @@ type testMemClient struct {
 	headErr   error
 	listErr   error
 	healthErr error
+
+	// getDelay stalls Get before it returns, so a test can make a response take
+	// longer to deliver than the server's WriteTimeout allows without needing a
+	// payload large enough to be slow on its own merits (#75). Set before the
+	// client is handed to a coordinator; not mutated afterwards.
+	getDelay time.Duration
 }
 
 func newTestMemClient(objs map[string][]byte) *testMemClient {
@@ -45,6 +51,9 @@ func newTestMemClient(objs map[string][]byte) *testMemClient {
 }
 
 func (m *testMemClient) Get(_ context.Context, key string, _, _ int64) ([]byte, error) {
+	if m.getDelay > 0 {
+		time.Sleep(m.getDelay)
+	}
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
@@ -1622,6 +1631,212 @@ func TestSitesList_WithCircuitBreaker_Open(t *testing.T) {
 	}
 	if sites[0].CircuitState != "open" {
 		t.Errorf("circuit_state: got %q, want %q", sites[0].CircuitState, "open")
+	}
+}
+
+// ── Transfer deadlines (#75) ──────────────────────────────────────────────────
+
+// TestTransferDeadline_Sizing covers the budget arithmetic: proportional to size
+// at minTransferThroughputBytesPerSec, clamped at both ends.
+func TestTransferDeadline_Sizing(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		size int64
+		want time.Duration
+	}{
+		{"unknown length gets the floor", -1, minTransferDeadline},
+		{"zero gets the floor", 0, minTransferDeadline},
+		{"small object gets the floor", 4096, minTransferDeadline},
+		{"floor holds up to its equivalent size", 30 << 20, minTransferDeadline},
+		{"64 MiB at 1 MiB/s", 64 << 20, 64 * time.Second},
+		{"documented 256 MiB cap is reachable", maxObjectBodyBytes, 256 * time.Second},
+		{"absurd size is capped", 1 << 40, maxTransferDeadline},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := transferDeadline(tc.size); got != tc.want {
+				t.Errorf("transferDeadline(%d) = %v, want %v", tc.size, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTransferDeadline_SizeCapIsReachable is the consistency check the issue asks
+// for: an advertised limit that cannot be reached at realistic bandwidth is a
+// defect. The budget for a maximum-size body must be at least the time that body
+// takes at the throughput floor.
+func TestTransferDeadline_SizeCapIsReachable(t *testing.T) {
+	t.Parallel()
+
+	needed := time.Duration(maxObjectBodyBytes/minTransferThroughputBytesPerSec) * time.Second
+	if got := transferDeadline(maxObjectBodyBytes); got < needed {
+		t.Errorf("a %d-byte body gets %v but needs %v at %d B/s — the documented cap "+
+			"is unreachable (#75)", maxObjectBodyBytes, got, needed, minTransferThroughputBytesPerSec)
+	}
+	if maxTransferDeadline < needed {
+		t.Errorf("maxTransferDeadline (%v) is below the time a maximum-size body needs "+
+			"(%v): the cap and the timeout contradict each other", maxTransferDeadline, needed)
+	}
+}
+
+// TestStatusRecorder_UnwrapReachesDeadlineControl is a small test for the trap
+// that makes the rest of #75's fix a no-op.
+//
+// loggingMiddleware and withObjectMetrics both wrap the ResponseWriter in a
+// statusRecorder, and http.ResponseController finds SetWriteDeadline by walking
+// Unwrap. Without statusRecorder.Unwrap every deadline call returns
+// ErrNotSupported and quietly does nothing, so the handlers keep the 10s
+// server-wide deadline and the bug survives a fix that looks correct. Verified to
+// fail with the Unwrap method removed.
+func TestStatusRecorder_UnwrapReachesDeadlineControl(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := httptest.NewServer(withObjectMetrics("get", nil,
+		loggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Two statusRecorder layers deep, as in the real chain.
+			errCh <- http.NewResponseController(w).SetWriteDeadline(time.Now().Add(time.Minute))
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if err := <-errCh; err != nil {
+		t.Errorf("SetWriteDeadline through the middleware chain: %v — the deadline "+
+			"never reaches the connection, so #75 is unfixed", err)
+	}
+}
+
+// TestObjectGet_LargeBodyNotTruncated is the end-to-end regression test for #75.
+//
+// It runs a real http.Server with WriteTimeout deliberately far shorter than the
+// response takes to deliver, which is the production shape of the bug: an
+// absolute deadline on the whole response rather than an idle one. The handler
+// must extend it per request and the client must receive every byte.
+//
+// The coordinator's Get is made slow rather than the object made huge: a 64 MiB
+// payload would be needed to beat a 10s timeout honestly, and a slow Get with a
+// 1s timeout tests the same deadline arithmetic in a second rather than a minute.
+func TestObjectGet_LargeBodyNotTruncated(t *testing.T) {
+	// The payload has to exceed the socket buffers, or the whole response is
+	// buffered by the kernel and returns before any deadline could bite.
+	const size = 8 << 20
+	payload := bytes.Repeat([]byte("A"), size)
+
+	c, mc := makeTestCoordinator(t, map[string][]byte{"big.bin": payload})
+	mc.getDelay = 2 * time.Second // exceeds the server's WriteTimeout below
+
+	mux := http.NewServeMux()
+	registerAPIRoutes(mux, context.Background(), c, nil, config.SecurityConfig{})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler:      buildHandler(mux, ""),
+		ReadTimeout:  1 * time.Second,
+		WriteTimeout: 1 * time.Second, // shorter than the response takes
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	resp, err := http.Get("http://" + ln.Addr().String() + "/api/v1/objects/big.bin")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	if got := resp.ContentLength; got != size {
+		t.Fatalf("Content-Length: got %d, want %d", got, size)
+	}
+
+	// io.ReadAll's error is the whole point: a truncated body shows up here as
+	// "unexpected EOF" against an accurate Content-Length, which is exactly what
+	// the issue reports.
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v — the response was truncated after %d of %d bytes "+
+			"because WriteTimeout is an absolute deadline (#75)", err, len(got), size)
+	}
+	if len(got) != size {
+		t.Errorf("body length: got %d, want %d (truncated mid-body, #75)", len(got), size)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Error("body content differs from the stored object")
+	}
+}
+
+// TestObjectPut_SlowUploadNotCutOff is the same defect in the read direction: a
+// body arriving more slowly than ReadTimeout allows must still be accepted, which
+// is what makes the documented 256 MiB cap reachable below 25.6 MiB/s.
+func TestObjectPut_SlowUploadNotCutOff(t *testing.T) {
+	const size = 1 << 20
+	payload := bytes.Repeat([]byte("B"), size)
+
+	c, mc := makeTestCoordinator(t, nil)
+
+	mux := http.NewServeMux()
+	registerAPIRoutes(mux, context.Background(), c, nil, config.SecurityConfig{})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler:      buildHandler(mux, ""),
+		ReadTimeout:  1 * time.Second, // shorter than the upload takes
+		WriteTimeout: 1 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// A body delivered in chunks over ~2s, with an accurate Content-Length so the
+	// handler can size the deadline from it.
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		const chunks = 8
+		for i := 0; i < chunks; i++ {
+			if _, err := pw.Write(payload[i*size/chunks : (i+1)*size/chunks]); err != nil {
+				return
+			}
+			time.Sleep(250 * time.Millisecond)
+		}
+	}()
+
+	req, err := http.NewRequest(http.MethodPut,
+		"http://"+ln.Addr().String()+"/api/v1/objects/slow.bin", pr)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.ContentLength = size
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v — a slow upload was cut off by the server-wide "+
+			"ReadTimeout (#75)", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d (%s), want 201", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if !mc.hasKey("slow.bin") {
+		t.Error("object was not stored")
 	}
 }
 

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -1284,7 +1284,7 @@ func TestValidateS3Endpoint_Allowed(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if err, reason := validateS3Endpoint(context.Background(), tc.endpoint, tc.sec, resolve); err != nil {
+			if reason, err := validateS3Endpoint(context.Background(), tc.endpoint, tc.sec, resolve); err != nil {
 				t.Errorf("validateS3Endpoint(%q) = %v (%s), want nil", tc.endpoint, err, reason)
 			}
 		})
@@ -1324,7 +1324,7 @@ func TestValidateS3Endpoint_ResolvedAddressIsChecked(t *testing.T) {
 		"nxdomain.example",
 	} {
 		endpoint := "https://" + host
-		err, reason := validateS3Endpoint(context.Background(), endpoint, config.SecurityConfig{}, resolve)
+		reason, err := validateS3Endpoint(context.Background(), endpoint, config.SecurityConfig{}, resolve)
 		if err == nil {
 			t.Errorf("validateS3Endpoint(%q) = nil, want rejection — a DNS name pointing at "+
 				"an internal address must be caught after resolution (#76)", endpoint)
@@ -1708,7 +1708,7 @@ func TestStatusRecorder_UnwrapReachesDeadlineControl(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if err := <-errCh; err != nil {
 		t.Errorf("SetWriteDeadline through the middleware chain: %v — the deadline "+
@@ -1754,7 +1754,7 @@ func TestObjectGet_LargeBodyNotTruncated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", resp.StatusCode)
@@ -1807,7 +1807,7 @@ func TestObjectPut_SlowUploadNotCutOff(t *testing.T) {
 	// handler can size the deadline from it.
 	pr, pw := io.Pipe()
 	go func() {
-		defer pw.Close()
+		defer func() { _ = pw.Close() }()
 		const chunks = 8
 		for i := 0; i < chunks; i++ {
 			if _, err := pw.Write(payload[i*size/chunks : (i+1)*size/chunks]); err != nil {
@@ -1829,7 +1829,7 @@ func TestObjectPut_SlowUploadNotCutOff(t *testing.T) {
 		t.Fatalf("PUT: %v — a slow upload was cut off by the server-wide "+
 			"ReadTimeout (#75)", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
@@ -1919,7 +1919,7 @@ func TestPathTraversal_RejectedNotRedirected(t *testing.T) {
 			if err != nil {
 				t.Fatalf("request: %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if loc := resp.Header.Get("Location"); loc != "" {
 				t.Errorf("%s %s: served a redirect to %q — a client that follows it "+
@@ -1953,7 +1953,7 @@ func TestPathTraversal_DoesNotReachSiteHandlers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNoContent {
 		t.Errorf("traversal returned 204 — the site deregistration succeeded (#73)")
@@ -1980,7 +1980,7 @@ func TestPathTraversal_AuthCheckedBeforePathGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("unauthenticated traversal: got %d, want 401", resp.StatusCode)
 	}
@@ -1992,7 +1992,7 @@ func TestPathTraversal_AuthCheckedBeforePathGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
-	defer resp2.Body.Close()
+	defer func() { _ = resp2.Body.Close() }()
 	if resp2.StatusCode != http.StatusBadRequest {
 		t.Errorf("authenticated traversal: got %d, want 400", resp2.StatusCode)
 	}
@@ -2030,7 +2030,7 @@ func TestPathTraversal_LegitimateKeysStillWork(t *testing.T) {
 			if err != nil {
 				t.Fatalf("request: %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != http.StatusCreated {
 				body, _ := io.ReadAll(resp.Body)

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/scttfrdmn/globalfs/internal/circuitbreaker"
 	"github.com/scttfrdmn/globalfs/internal/coordinator"
+	"github.com/scttfrdmn/globalfs/pkg/config"
 	"github.com/scttfrdmn/globalfs/pkg/site"
 	"github.com/scttfrdmn/globalfs/pkg/types"
 )
@@ -424,7 +426,7 @@ func TestObjectHead_CoordinatorError(t *testing.T) {
 func TestObjectAPI_FullRoundtrip(t *testing.T) {
 	c, _ := makeTestCoordinator(t, nil)
 	mux := http.NewServeMux()
-	registerAPIRoutes(mux, context.Background(), c, nil)
+	registerAPIRoutes(mux, context.Background(), c, nil, config.SecurityConfig{})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
@@ -1045,7 +1047,7 @@ func TestAddSite_MissingName(t *testing.T) {
 	body := `{"s3_bucket":"bucket","s3_region":"us-west-2"}`
 	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body))
 	w := httptest.NewRecorder()
-	addSiteHandler(context.Background(), c)(w, req)
+	addSiteHandler(context.Background(), c, config.SecurityConfig{})(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("missing name: expected 400, got %d", w.Code)
@@ -1059,7 +1061,7 @@ func TestAddSite_MissingBucket(t *testing.T) {
 	body := `{"name":"site2","s3_region":"us-west-2"}`
 	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body))
 	w := httptest.NewRecorder()
-	addSiteHandler(context.Background(), c)(w, req)
+	addSiteHandler(context.Background(), c, config.SecurityConfig{})(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("missing bucket: expected 400, got %d", w.Code)
@@ -1073,7 +1075,7 @@ func TestAddSite_InvalidRole(t *testing.T) {
 	body := `{"name":"site2","s3_bucket":"b","s3_region":"us-west-2","role":"invalid"}`
 	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body))
 	w := httptest.NewRecorder()
-	addSiteHandler(context.Background(), c)(w, req)
+	addSiteHandler(context.Background(), c, config.SecurityConfig{})(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("invalid role: expected 400, got %d", w.Code)
@@ -1086,7 +1088,7 @@ func TestAddSite_InvalidJSON(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader("{not json}"))
 	w := httptest.NewRecorder()
-	addSiteHandler(context.Background(), c)(w, req)
+	addSiteHandler(context.Background(), c, config.SecurityConfig{})(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("invalid JSON: expected 400, got %d", w.Code)
@@ -1096,6 +1098,13 @@ func TestAddSite_InvalidJSON(t *testing.T) {
 func TestAddSite_S3Unreachable_Returns502(t *testing.T) {
 	// Provides a syntactically valid request that will fail to connect.
 	// We use a context with a short timeout so the test does not hang.
+	//
+	// The endpoint is loopback, which the #76 SSRF guard blocks by default — so
+	// this test now allowlists that host explicitly. That is the point of the
+	// allowlist: reaching an unreachable loopback port is a legitimate thing for
+	// an operator to configure, and an unremarkable thing for a caller to be
+	// denied. Without the allowlist entry this request is a 400, and
+	// TestAddSite_EndpointRejected_Loopback asserts exactly that.
 	c, _ := makeTestCoordinator(t, nil)
 
 	body := `{"name":"remote","s3_bucket":"bucket","s3_region":"us-east-1","s3_endpoint":"http://127.0.0.1:19999"}`
@@ -1103,10 +1112,258 @@ func TestAddSite_S3Unreachable_Returns502(t *testing.T) {
 	defer cancel()
 	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body)).WithContext(ctx)
 	w := httptest.NewRecorder()
-	addSiteHandler(context.Background(), c)(w, req)
+	sec := config.SecurityConfig{AllowedEndpointHosts: []string{"127.0.0.1"}}
+	addSiteHandler(context.Background(), c, sec)(w, req)
 
 	if w.Code != http.StatusBadGateway {
 		t.Errorf("unreachable S3: expected 502, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The 502 body must not carry the transport error: an open non-HTTP port and
+	// a closed one produce different messages, which is a scan oracle (#76).
+	body502 := w.Body.String()
+	for _, leak := range []string{"connection refused", "dial tcp", "127.0.0.1", "malformed HTTP response"} {
+		if strings.Contains(body502, leak) {
+			t.Errorf("502 body leaks transport detail %q: %s", leak, body502)
+		}
+	}
+}
+
+// ── s3_endpoint SSRF guard (#76) ──────────────────────────────────────────────
+
+// TestAddSite_EndpointRejected_NoSignedRequestSent is the end-to-end assertion
+// for #76: pointing s3_endpoint at a listener the caller controls must not cause
+// the coordinator to send it anything.
+//
+// Pre-fix the handler passed the endpoint straight to objectfssdk.WithEndpoint
+// and site.NewFromConfig performed a HeadBucket against it, delivering a live
+// SigV4 Authorization header derived from the coordinator's own AWS credentials.
+// The listener here stands in for the attacker's host: receiving *any* request
+// on it is the failure, so the assertion is a request count of zero rather than
+// a status code. It is allowlisted so that only the address checks are out of
+// the way — the guard's URL-shape rules still apply, and the endpoint is
+// otherwise a perfectly ordinary one.
+func TestAddSite_EndpointRejected_NoSignedRequestSent(t *testing.T) {
+	var mu sync.Mutex
+	var received []string
+
+	victim := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		received = append(received, r.Method+" "+r.URL.Path+" auth="+r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer victim.Close()
+
+	c, _ := makeTestCoordinator(t, nil)
+
+	// Not allowlisted, and loopback: must be rejected before anything is signed.
+	body := `{"name":"probe","s3_bucket":"probe","s3_region":"us-west-2","s3_endpoint":"` + victim.URL + `"}`
+	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	addSiteHandler(context.Background(), c, config.SecurityConfig{})(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 0 {
+		t.Errorf("coordinator sent %d request(s) to a caller-chosen host — SSRF with "+
+			"signed credentials (#76): %v", len(received), received)
+	}
+}
+
+// TestAddSite_EndpointRejected covers the endpoint shapes the handler must refuse
+// before signing anything, and asserts the response body carries no detail about
+// why (the reason goes to the log; see errEndpointRejected).
+func TestAddSite_EndpointRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		endpoint string
+	}{
+		{"link-local IMDS", "http://169.254.169.254"},
+		{"IMDS with path", "http://169.254.169.254/latest/meta-data/"},
+		{"loopback v4", "http://127.0.0.1:9000"},
+		{"loopback name", "http://localhost:9000"},
+		{"loopback v6", "http://[::1]:9000"},
+		{"private RFC1918 10/8", "http://10.0.0.5:9000"},
+		{"private RFC1918 192.168/16", "http://192.168.1.10:9000"},
+		{"private RFC1918 172.16/12", "http://172.16.0.1:9000"},
+		{"CGNAT 100.64/10", "http://100.64.0.1:9000"},
+		{"IPv6 link-local", "http://[fe80::1]:9000"},
+		{"IPv6 unique-local", "http://[fd00::1]:9000"},
+		{"unspecified v4", "http://0.0.0.0:9000"},
+		{"file scheme", "file:///etc/passwd"},
+		{"gopher scheme", "gopher://10.0.0.1:70"},
+		{"no scheme", "169.254.169.254"},
+		{"scheme only", "http://"},
+		{"userinfo", "http://user:pass@s3.example.com"},
+		{"query string", "http://s3.example.com?x=1"},
+		{"fragment", "http://s3.example.com#f"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c, _ := makeTestCoordinator(t, nil)
+
+			body := `{"name":"x","s3_bucket":"b","s3_region":"us-west-2","s3_endpoint":"` + tc.endpoint + `"}`
+			req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			addSiteHandler(context.Background(), c, config.SecurityConfig{})(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("endpoint %q: got %d, want 400: %s", tc.endpoint, w.Code, w.Body.String())
+			}
+			// The response must not explain itself: "connection refused" vs
+			// "malformed HTTP response" vs "link-local" are all distinguishing
+			// signals a scanner can read.
+			for _, leak := range []string{"link-local", "loopback", "private", "resolve", "dial"} {
+				if strings.Contains(strings.ToLower(w.Body.String()), leak) {
+					t.Errorf("endpoint %q: response body leaks the reason %q: %s",
+						tc.endpoint, leak, w.Body.String())
+				}
+			}
+			if got := len(c.Sites()); got != 1 {
+				t.Errorf("site count changed to %d; the rejected site was registered", got)
+			}
+		})
+	}
+}
+
+// TestValidateS3Endpoint_Allowed covers the values that must keep working: an
+// empty endpoint (use AWS's default), an ordinary public host, and the two
+// escape hatches operators need.
+func TestValidateS3Endpoint_Allowed(t *testing.T) {
+	t.Parallel()
+
+	// A resolver that answers deterministically, so the test does not depend on
+	// DNS. "public.example" is public; "internal.example" is RFC1918.
+	resolve := func(_ context.Context, host string) ([]net.IPAddr, error) {
+		switch host {
+		case "public.example":
+			return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+		case "internal.example":
+			return []net.IPAddr{{IP: net.ParseIP("10.1.2.3")}}, nil
+		}
+		return nil, errors.New("no such host")
+	}
+
+	cases := []struct {
+		name     string
+		endpoint string
+		sec      config.SecurityConfig
+	}{
+		{"empty means AWS default", "", config.SecurityConfig{}},
+		{"public host", "https://public.example", config.SecurityConfig{}},
+		{"public host with trailing slash", "https://public.example/", config.SecurityConfig{}},
+		{"public IP literal", "https://93.184.216.34", config.SecurityConfig{}},
+		{"private allowed by opt-in", "http://10.0.0.5:9000",
+			config.SecurityConfig{AllowPrivateEndpoints: true}},
+		{"private DNS name allowed by opt-in", "http://internal.example:9000",
+			config.SecurityConfig{AllowPrivateEndpoints: true}},
+		{"loopback allowed by allowlist", "http://127.0.0.1:4566",
+			config.SecurityConfig{AllowedEndpointHosts: []string{"127.0.0.1"}}},
+		{"allowlist is case-insensitive", "http://MinIO.Local:9000",
+			config.SecurityConfig{AllowedEndpointHosts: []string{"minio.local"}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err, reason := validateS3Endpoint(context.Background(), tc.endpoint, tc.sec, resolve); err != nil {
+				t.Errorf("validateS3Endpoint(%q) = %v (%s), want nil", tc.endpoint, err, reason)
+			}
+		})
+	}
+}
+
+// TestValidateS3Endpoint_ResolvedAddressIsChecked is the half of #76 that string
+// matching would miss: a public-looking DNS name whose A record points into
+// private or link-local space. The check runs after resolution, and every answer
+// must pass — one public address does not license a second internal one.
+func TestValidateS3Endpoint_ResolvedAddressIsChecked(t *testing.T) {
+	t.Parallel()
+
+	resolve := func(_ context.Context, host string) ([]net.IPAddr, error) {
+		switch host {
+		case "imds.attacker.example":
+			return []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}, nil
+		case "internal.attacker.example":
+			return []net.IPAddr{{IP: net.ParseIP("10.0.0.1")}}, nil
+		case "mixed.attacker.example":
+			// One public answer and one internal: must still be rejected.
+			return []net.IPAddr{
+				{IP: net.ParseIP("93.184.216.34")},
+				{IP: net.ParseIP("169.254.169.254")},
+			}, nil
+		case "empty.example":
+			return nil, nil
+		}
+		return nil, errors.New("no such host")
+	}
+
+	for _, host := range []string{
+		"imds.attacker.example",
+		"internal.attacker.example",
+		"mixed.attacker.example",
+		"empty.example",
+		"nxdomain.example",
+	} {
+		endpoint := "https://" + host
+		err, reason := validateS3Endpoint(context.Background(), endpoint, config.SecurityConfig{}, resolve)
+		if err == nil {
+			t.Errorf("validateS3Endpoint(%q) = nil, want rejection — a DNS name pointing at "+
+				"an internal address must be caught after resolution (#76)", endpoint)
+			continue
+		}
+		if !errors.Is(err, errEndpointRejected) {
+			t.Errorf("validateS3Endpoint(%q) returned %v, want errEndpointRejected", endpoint, err)
+		}
+		if reason == "" {
+			t.Errorf("validateS3Endpoint(%q) gave no reason to log", endpoint)
+		}
+	}
+}
+
+// TestIsDisallowedAddr_PrivateOptInDoesNotUnblockLinkLocal pins the deliberate
+// asymmetry in the opt-in: allow_private_endpoints exists for in-cluster MinIO on
+// an RFC1918 address, and must not thereby open 169.254.169.254 or loopback.
+func TestIsDisallowedAddr_PrivateOptInDoesNotUnblockLinkLocal(t *testing.T) {
+	t.Parallel()
+
+	stillBlocked := []string{
+		"169.254.169.254", // IMDS
+		"127.0.0.1",
+		"::1",
+		"fe80::1",
+		"0.0.0.0",
+		"224.0.0.1", // multicast
+	}
+	for _, s := range stillBlocked {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("bad test address %q", s)
+		}
+		if bad, _ := isDisallowedAddr(ip, true); !bad {
+			t.Errorf("isDisallowedAddr(%s, allowPrivate=true) = false; "+
+				"the private opt-in must not unblock this class (#76)", s)
+		}
+	}
+
+	// And the addresses the opt-in is actually for do become allowed.
+	for _, s := range []string{"10.0.0.5", "192.168.1.1", "172.16.0.1", "fd00::1", "100.64.0.1"} {
+		ip := net.ParseIP(s)
+		if bad, _ := isDisallowedAddr(ip, false); !bad {
+			t.Errorf("isDisallowedAddr(%s, allowPrivate=false) = false, want blocked", s)
+		}
+		if bad, reason := isDisallowedAddr(ip, true); bad {
+			t.Errorf("isDisallowedAddr(%s, allowPrivate=true) = true (%s), want allowed", s, reason)
+		}
 	}
 }
 
@@ -1379,7 +1636,7 @@ func makeTestServer(t *testing.T, objs map[string][]byte, apiKey string) (*httpt
 	t.Helper()
 	c, mc := makeTestCoordinator(t, objs)
 	mux := http.NewServeMux()
-	registerAPIRoutes(mux, context.Background(), c, nil)
+	registerAPIRoutes(mux, context.Background(), c, nil, config.SecurityConfig{})
 	srv := httptest.NewServer(buildHandler(mux, apiKey))
 	t.Cleanup(srv.Close)
 	return srv, c, mc

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -247,7 +247,7 @@ func main() {
 	mux.HandleFunc("/readyz", readyzHandler())
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("GET /api/v1/info", infoHandler(c, version, startTime))
-	registerAPIRoutes(mux, ctx, c, m)
+	registerAPIRoutes(mux, ctx, c, m, cfg.Security)
 
 	// buildHandler applies the middleware chain; see its doc comment for the
 	// order and why the path-traversal guard has to wrap the mux directly.

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -249,17 +249,12 @@ func main() {
 	mux.HandleFunc("GET /api/v1/info", infoHandler(c, version, startTime))
 	registerAPIRoutes(mux, ctx, c, m)
 
-	// Build middleware chain (applied innermost → outermost):
-	//   mux → apiKey (when set) → logging → requestID
-	// requestID is outermost: every response gets a correlation ID.
-	// logging wraps apiKey so auth rejections are also recorded.
-	var handler http.Handler = mux
+	// buildHandler applies the middleware chain; see its doc comment for the
+	// order and why the path-traversal guard has to wrap the mux directly.
 	if apiKey != "" {
-		handler = apiKeyMiddleware(apiKey)(handler)
 		slog.Info("API key authentication enabled")
 	}
-	handler = loggingMiddleware(handler)
-	handler = requestIDMiddleware(handler)
+	handler := buildHandler(mux, apiKey)
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -87,7 +87,7 @@ func main() {
 		addr = cfg.Coordinator.ListenAddr
 	}
 	if addr == "" {
-		addr = ":8090"
+		addr = config.DefaultListenAddr
 	}
 
 	// Override log level from config only when the --log-level flag was not

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -256,6 +256,14 @@ func main() {
 	}
 	handler := buildHandler(mux, apiKey)
 
+	// ReadTimeout and WriteTimeout are absolute deadlines on the whole request and
+	// the whole response, not idle timeouts. These values are correct for the JSON
+	// control endpoints and wrong for the object routes sharing this server, which
+	// is why the object handlers replace them per request via
+	// http.ResponseController — see the transfer-deadline block in api.go. They
+	// are kept strict here so that a slow or stalled control-plane request is
+	// still cut off promptly; raising them globally would have been the wrong fix
+	// for #75, since it weakens every endpoint to accommodate two.
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           handler,

--- a/cmd/globalfs/main.go
+++ b/cmd/globalfs/main.go
@@ -77,7 +77,7 @@ func buildRoot() *cobra.Command {
 	root.PersistentFlags().StringVar(
 		&coordinatorAddr,
 		"coordinator-addr",
-		envOrDefault("GLOBALFS_COORDINATOR", "http://localhost:8090"),
+		envOrDefault("GLOBALFS_COORDINATOR", config.DefaultCoordinatorURL),
 		"Coordinator HTTP address (env: GLOBALFS_COORDINATOR)",
 	)
 	root.PersistentFlags().StringVar(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,7 +11,7 @@ global:
 
 # Coordinator settings
 coordinator:
-  listen_addr: ":8080"
+  listen_addr: ":8090"
   etcd_endpoints:
     - "localhost:2379"
     - "localhost:2380"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,6 +189,30 @@ type CargoShipConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+// The coordinator's port is defined once, here, and every other default is
+// derived from it by string concatenation at compile time.  Before #81 the
+// daemon default (":8080", in NewDefault below) and the CLI default
+// ("http://localhost:8090", in cmd/globalfs) were independent literals, so
+// starting the coordinator without a config file left every CLI command
+// talking to a closed port.  Restating the literal in two packages is the
+// defect; the constants below are the fix, and TestDefaultPorts_DaemonAndCLIAgree
+// keeps them honest.
+const (
+	// DefaultListenPort is the coordinator daemon's HTTP port.  Change it here
+	// and both DefaultListenAddr and DefaultCoordinatorURL follow.
+	DefaultListenPort = "8090"
+
+	// DefaultListenAddr is the coordinator daemon's default HTTP bind address,
+	// used by NewDefault and as the last resort in cmd/coordinator when neither
+	// --bind-addr nor coordinator.listen_addr is set.
+	DefaultListenAddr = ":" + DefaultListenPort
+
+	// DefaultCoordinatorURL is the CLI's default --coordinator-addr value
+	// (env: GLOBALFS_COORDINATOR).  It points at a coordinator running on this
+	// host with DefaultListenAddr.
+	DefaultCoordinatorURL = "http://localhost:" + DefaultListenPort
+)
+
 // NewDefault returns a default configuration.
 func NewDefault() *Configuration {
 	return &Configuration{
@@ -199,7 +223,7 @@ func NewDefault() *Configuration {
 			MetricsPort:    9090,
 		},
 		Coordinator: types.CoordinatorConfig{
-			ListenAddr:    ":8080",
+			ListenAddr:    DefaultListenAddr,
 			EtcdEndpoints: []string{"localhost:2379"},
 			LeaseTimeout:  60 * time.Second,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,39 @@ type CacheConfig struct {
 	TTL time.Duration `yaml:"ttl"`
 }
 
+// SecurityConfig groups settings that constrain what the coordinator will do on
+// behalf of an API caller.
+//
+// It exists because POST /api/v1/sites accepts an s3_endpoint and the
+// coordinator then signs a HeadBucket against it with its own AWS credentials.
+// Unconstrained, that is an SSRF primitive that hands a live SigV4
+// Authorization header to any host the caller names, including link-local IMDS
+// (#76).  The defaults below block that; these fields are the escape hatch for
+// operators whose storage genuinely is on a private address.
+//
+// Endpoints in the `sites:` block of a config file are not subject to these
+// checks.  A config file is operator-supplied input, the API is not.
+type SecurityConfig struct {
+	// AllowPrivateEndpoints permits site endpoints that resolve into private
+	// address space (RFC1918, RFC4193 unique-local, RFC6598 CGNAT) — the case
+	// for an in-cluster MinIO.  Default false.
+	//
+	// It deliberately does not unblock loopback, link-local, unspecified, or
+	// multicast addresses: 169.254.169.254 is the highest-value target here and
+	// no legitimate S3 endpoint lives there.  Use AllowedEndpointHosts for
+	// those.
+	AllowPrivateEndpoints bool `yaml:"allow_private_endpoints"`
+
+	// AllowedEndpointHosts is an exact-match allowlist of endpoint hosts that
+	// skip address checks entirely.  Compared case-insensitively against the
+	// URL host with any port removed; a hostname or an IP literal both work.
+	//
+	// This is the narrow escape hatch — naming one host is a much smaller grant
+	// than unblocking a whole address class, and it is the only way to permit a
+	// loopback endpoint.
+	AllowedEndpointHosts []string `yaml:"allowed_endpoint_hosts"`
+}
+
 // ResilienceConfig groups fault-tolerance and health-monitoring settings.
 type ResilienceConfig struct {
 	// HealthPollInterval sets the background site health check cadence.
@@ -130,6 +163,10 @@ type Configuration struct {
 
 	// Cache configures the in-memory LRU object cache.
 	Cache CacheConfig `yaml:"cache"`
+
+	// Security constrains what the API will accept from a caller — currently
+	// which S3 endpoints a runtime site registration may point at.
+	Security SecurityConfig `yaml:"security"`
 }
 
 // GlobalConfig contains global settings.
@@ -251,6 +288,12 @@ func NewDefault() *Configuration {
 			Enabled:  false,
 			MaxBytes: 64 * 1024 * 1024, // 64 MiB
 			TTL:      0,
+		},
+		Security: SecurityConfig{
+			// Deny by default: an operator who needs an in-cluster endpoint opts
+			// in, rather than every deployment shipping an SSRF primitive so that
+			// the MinIO case works unconfigured.
+			AllowPrivateEndpoints: false,
 		},
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -586,6 +588,75 @@ func TestShippedConfigsAreValid(t *testing.T) {
 			}
 			if err := cfg.Validate(); err != nil {
 				t.Errorf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+// TestDefaultPorts_DaemonAndCLIAgree is the regression test for #81: the daemon
+// default (NewDefault().Coordinator.ListenAddr) was ":8080" while the CLI default
+// (cmd/globalfs, --coordinator-addr) was "http://localhost:8090", so a coordinator
+// started with no config file listened on a port no CLI command ever dialled.
+//
+// Changing the ":8080" literal alone would have left the same failure mode one
+// refactor away, so both defaults now derive from DefaultListenPort. This test
+// asserts the derivation still holds: if someone reintroduces a bare literal in
+// either place, the port comparison below fails.
+func TestDefaultPorts_DaemonAndCLIAgree(t *testing.T) {
+	t.Parallel()
+
+	// The daemon default must come from the shared constant, not a literal.
+	if got := config.NewDefault().Coordinator.ListenAddr; got != config.DefaultListenAddr {
+		t.Errorf("NewDefault().Coordinator.ListenAddr = %q, want %q", got, config.DefaultListenAddr)
+	}
+
+	// The daemon listen address must be a host:port that net.Listen accepts, and
+	// its port is the one a client has to dial.
+	_, daemonPort, err := net.SplitHostPort(config.DefaultListenAddr)
+	if err != nil {
+		t.Fatalf("DefaultListenAddr %q is not a valid host:port: %v", config.DefaultListenAddr, err)
+	}
+
+	// The CLI default must be an absolute http URL pointing at that same port.
+	u, err := url.Parse(config.DefaultCoordinatorURL)
+	if err != nil {
+		t.Fatalf("DefaultCoordinatorURL %q does not parse: %v", config.DefaultCoordinatorURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		t.Errorf("DefaultCoordinatorURL scheme = %q, want http or https", u.Scheme)
+	}
+	if u.Port() != daemonPort {
+		t.Errorf("CLI default dials port %q but the daemon listens on %q (%q vs %q) — "+
+			"the out-of-the-box experience is broken (#81)",
+			u.Port(), daemonPort, config.DefaultCoordinatorURL, config.DefaultListenAddr)
+	}
+}
+
+// TestShippedConfigs_ListenAddrMatchesDefault keeps the YAML files users copy in
+// agreement with the compiled-in default. config.example.yaml said ":8080" while
+// examples/coordinator-config.yaml and the `config init` template said ":8090";
+// copying the former produced the #81 failure even with an explicit config file.
+func TestShippedConfigs_ListenAddrMatchesDefault(t *testing.T) {
+	t.Parallel()
+
+	// Relative to pkg/config/, where this test runs.
+	shipped := []string{
+		"../../config.example.yaml",
+		"../../examples/coordinator-config.yaml",
+	}
+
+	for _, path := range shipped {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.NewDefault()
+			if err := cfg.LoadFromFile(path); err != nil {
+				t.Fatalf("LoadFromFile: %v", err)
+			}
+			if got := cfg.Coordinator.ListenAddr; got != config.DefaultListenAddr {
+				t.Errorf("coordinator.listen_addr = %q, want %q — a user who copies this "+
+					"file gets a coordinator the CLI default cannot reach (#81)",
+					got, config.DefaultListenAddr)
 			}
 		})
 	}


### PR DESCRIPTION
Four independent fixes, one commit each. Refs #73, #75, #76, #81 — deliberately not using `Closes`, so they can be closed manually after review.

## #73 — path traversal crosses the authorization boundary (critical)

`http.ServeMux` path-cleans and issues a 307 *before* handler dispatch, so `validateObjectKey` never saw a literal `..`. `DELETE /api/v1/objects/../sites/primary` returned `307 Location: /api/v1/sites/primary`, and Go's `http.Client` replays both the method and the `X-GlobalFS-API-Key` header across a 307 — so `client.DeleteObject(ctx, "../sites/primary")` deregistered a site and returned `nil`.

The fix cannot live in the handlers. `rejectUnsafePath` middleware wraps the mux and inspects `r.URL.EscapedPath()` (not `r.URL.Path`, which is already percent-decoded), rejecting any request whose path has a `..` component, a null byte, or malformed escaping, with `400`.

- Decoding is **single-pass**. Double-decoding would reject the legal key `pct%252E%252E/f`.
- `..` is only rejected as a whole component: `a..b`, `snapshot..`, `v1..2/file.bam` still work.
- Middleware order is a security property: the guard sits *inside* auth (unauthenticated traversal → `401`, not `400`) and *outside* the mux. `buildHandler` was extracted from `main()` specifically so the tests drive the real chain, mux included — a test against the bare handler would pass on the vulnerable tree.
- `validateObjectKey` is kept as a second layer with a comment saying it is no longer load-bearing. It still catches the escaped-separator case (`%2F%2E%2E%2F`, which reaches the handler as key `/../sites/primary`) and guards direct handler callers.

## #76 — SSRF with live signed AWS credentials via `s3_endpoint`

`POST /api/v1/sites` made the coordinator sign a `HeadBucket` against a caller-chosen endpoint with its own credentials. Reproduced end to end: an in-process listener at an attacker-named address received `HEAD /probe` with `Authorization: AWS4-HMAC-SHA256 Credential=AKIA…/20260809/us-west-2/s3/aws4_request, …, Signature=f77b…`, and the API returned `201`.

`validateS3Endpoint` now runs *before* anything is constructed: absolute `http`/`https` origin only (no userinfo/path/query/fragment), then DNS resolution, then an address check on **every** returned address — loopback, link-local (IMDS at `169.254.169.254`), unspecified, multicast always blocked; private space (RFC1918, RFC4193, RFC6598 CGNAT) blocked unless `security.allow_private_endpoints`. Resolve-then-check, not string matching, so a public hostname pointing at an internal address is caught.

- `allow_private_endpoints: true` does **not** unblock loopback or link-local. `security.allowed_endpoint_hosts` is the narrow per-host escape hatch.
- Rejection returns a generic `400` and unreachability a generic `502` (previously the error text was echoed). This removes a port-scan / internal-topology oracle; the detail goes to the log.
- Config-file `sites:` entries are intentionally *not* checked — a config file is operator input, the API is not.
- **Reviewer note / known gap:** the window between resolving and the SDK connecting is a DNS-rebinding window. Closing it needs the connection pinned to the resolved IP, which requires a custom `DialContext`. I read `objectfs/sdks/go/objectfs/options.go` and the SDK exposes no transport or HTTP-client option, so this is not fixable from this repo. Documented in code, the commit message, and the README rather than papered over.

## #75 — `WriteTimeout` truncates large object GETs mid-body

`ReadTimeout`/`WriteTimeout` are absolute deadlines on the whole request/response, not idle timeouts. At 10s any GET taking longer to write was truncated mid-body — the client saw a short read, not an error status. The same math made the documented 256 MiB PUT cap unreachable (it needs a sustained 25.6 MiB/s).

Not fixed by raising the number: that weakens every control endpoint to accommodate two object routes, and any fixed budget still breaks at some size. The object handlers instead replace the deadline per request via `http.ResponseController`, sized from the bytes actually moving: `clamp(n / 1 MiB/s, 30s, 10m)`.

- 1 MiB/s was chosen so the documented cap is *reachable* (256s, inside the 10m ceiling). `TestTransferDeadline_SizeCapIsReachable` asserts that relationship, so raising `maxObjectSize` without revisiting the rate fails the build.
- 10m ceiling is the slowloris bound; 30s floor keeps small objects no tighter than control endpoints.
- `objectPutHandler` extends **both** deadlines: net/http arms both when request headers finish, so `WriteTimeout` is already counting down during upload and a slow body leaves no budget for the `201`. `TestObjectPut_SlowUploadNotCutOff` found this.
- **`statusRecorder.Unwrap()` is load-bearing.** `ResponseController` walks the `Unwrap` chain; without it every `SetWriteDeadline` returns `http.ErrNotSupported` and no-ops — the fix would look correct in review and be entirely absent at runtime. `TestStatusRecorder_UnwrapReachesDeadlineControl` pins it.

## #81 — daemon and CLI defaulted to different ports

`pkg/config` defaulted to `:8080`, `cmd/coordinator` to `:8090`, README to `:8090` throughout. Started without a config file, no CLI command could reach the daemon. One source of truth now: `config.DefaultListenPort` with `DefaultListenAddr`/`DefaultCoordinatorURL` derived at compile time; `:8090` confirmed as the value the docs and daemon already used.

**The issue was partly misdiagnosed.** It states both shipped example YAMLs already said `:8090`. `config.example.yaml:14` actually said `:8080`, so copying the shipped example reproduced the bug even *with* an explicit config file. Corrected. `TestShippedConfigs_ListenAddrMatchesDefault` now loads both YAMLs and asserts they match the constant.

## Verification

All run on the final tree:

```
go build ./...            ok
go vet ./...              ok
gofmt -l .                (empty)
go mod tidy               no diff
go test -race -timeout=5m ./...   all 15 packages ok
```

Pre-fix verification was done for all three code fixes (not just the two security ones) by reverting the change and confirming the new tests fail with real assertion messages, then restoring:

- **#73**: traversal cases return `307` with a `Location` header instead of `400`; the site-count assertion shows the site actually deregistered.
- **#76**: the victim listener records a request bearing a valid SigV4 signature; `201` returned.
- **#75**: `GET: … EOF` and `PUT: … use of closed network connection`.
- **#81**: reverting via `git stash` produced only a compile error, which proves nothing, so I instead reintroduced the old literals *while keeping the constants* — both tests then failed on the assertion (`ListenAddr = ":8080", want ":8090"`).

## Boundaries respected

This branch touches only `cmd/coordinator/{api,api_test,main}.go`, `cmd/globalfs/main.go`, `pkg/config/config{,_test}.go`, `README.md`, `config.example.yaml`. Nothing under `internal/coordinator`, `internal/replication`, `pkg/site`, `pkg/client`, and no `CHANGELOG.md` edit.

One consequence: the #73 defence-in-depth that belongs in `pkg/client` — rejecting a traversal key before it goes on the wire, and/or refusing to follow redirects so a 307 cannot replay the API key — is **not** included here, as `pkg/client` is owned by another agent. Worth a follow-up issue.
