### PR TITLE
fix: v0.2.2 coordinator routing and lifecycle issues (#77, #78, #79, #80)

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -610,7 +610,14 @@ func (c *Coordinator) Close() error {
 	return c.ns.Close()
 }
 
-// AddSite appends a site at the lowest priority.
+// AddSite appends a site at the lowest priority, without checking whether its
+// name is already taken.
+//
+// Prefer [Coordinator.AddSiteUnique] anywhere the name comes from outside the
+// process.  Site names are the only handle every other operation has on a site —
+// RemoveSite, Replicate and the health report all address sites by name — so two
+// sites sharing one is an ambiguity none of them can resolve (#80).  Config
+// loading rejects duplicates; the HTTP API historically did not.
 func (c *Coordinator) AddSite(s *site.SiteMount) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -619,31 +626,71 @@ func (c *Coordinator) AddSite(s *site.SiteMount) {
 	c.metricsSiteCount(len(c.sites))
 }
 
-// RemoveSite removes the site with the given name.
-// If no site with that name exists, this is a no-op.
-// RemoveSite removes the named site and reports whether it was found.
+// ErrDuplicateSite reports that a site with the requested name is already
+// registered.  An HTTP layer should map it to 409 Conflict.
+var ErrDuplicateSite = errors.New("site name already registered")
+
+// AddSiteUnique appends a site at the lowest priority, or returns an error
+// wrapping [ErrDuplicateSite] if a site with the same name is already
+// registered.  The site is left untouched — not closed — when rejected, since
+// the caller constructed it and is better placed to decide.
+//
+// The check and the append happen under one lock hold, so a caller cannot be
+// beaten to the name between deciding and acting; the same reason RemoveSite
+// reports a bool instead of exposing an existence check (#58).
+func (c *Coordinator) AddSiteUnique(s *site.SiteMount) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, existing := range c.sites {
+		if existing.Name() == s.Name() {
+			return fmt.Errorf("coordinator: add site %q: %w", s.Name(), ErrDuplicateSite)
+		}
+	}
+	c.sites = append(c.sites, s)
+	c.ns.AddSite(s)
+	c.metricsSiteCount(len(c.sites))
+	return nil
+}
+
+// RemoveSite removes the named site, closes it, and reports whether it was
+// found.  If no site has that name this is a no-op returning false.
+//
 // Returning a bool allows callers to distinguish "not found" from "removed"
 // atomically, eliminating the TOCTOU race in the HTTP handler (#58).
+//
+// Exactly one site is removed per call, even if several share the name: the
+// highest-priority match goes and the rest stay, so a second call removes the
+// next one.  The loop used to run to completion, keeping only the *last* match
+// while filtering out *all* of them — one DELETE emptied the whole set and closed
+// one site, leaking the S3 connection pools of the others and reintroducing the
+// leak #62 fixed by another route (#80).  Duplicate names should not exist
+// (AddSiteUnique and config validation both refuse them), but this is the
+// function whose contract that leak fix rests on, so it does not assume it.
 func (c *Coordinator) RemoveSite(name string) bool {
 	var removed *site.SiteMount
 	c.mu.Lock()
-	filtered := make([]*site.SiteMount, 0, len(c.sites))
-	for _, s := range c.sites {
-		if s.Name() == name {
-			removed = s
-		} else {
-			filtered = append(filtered, s)
+	for i, s := range c.sites {
+		if s.Name() != name {
+			continue
 		}
+		removed = s
+		remaining := make([]*site.SiteMount, 0, len(c.sites)-1)
+		remaining = append(remaining, c.sites[:i]...)
+		remaining = append(remaining, c.sites[i+1:]...)
+		c.sites = remaining
+		break
 	}
 	if removed == nil {
 		c.mu.Unlock()
 		return false
 	}
-	c.sites = filtered
 	c.ns = namespace.New(c.sites...)
 	c.metricsSiteCount(len(c.sites))
 	c.mu.Unlock()
 
+	// Close outside the lock: Close talks to the network and can block, and
+	// holding c.mu across it stalls every read and write on the coordinator.
+	// Keep it that way (#95 exists because Close does not).
 	if err := removed.Close(); err != nil {
 		slog.Warn("coordinator: RemoveSite close", "site", name, "error", err)
 	}

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -469,14 +469,38 @@ func (c *Coordinator) start(ctx context.Context) {
 // finish the current job.  If a leader lease is held it is released so that a
 // standby coordinator can take over immediately.  Calling Stop before Start is
 // safe.
+//
+// # Teardown order
+//
+// The producer is stopped before its consumer.  worker.Stop waits for the
+// in-flight transfer to finish, and that transfer emits a terminal event; if the
+// drain goroutine is torn down first there is nobody left to read it, and the
+// job stays in the store as a phantom while its content hash is lost (#78).
 func (c *Coordinator) Stop() {
 	c.mu.Lock()
 	storeCancel := c.storeCancel
 	leaderCancel := c.leaderCancel
 	l := c.leaderLease
+	store := c.store
 	c.mu.Unlock()
 
-	// Cancel both contexts: stops the drain goroutine and keepalive goroutine.
+	// 1. Stop the producer.  Returns once the in-flight job has settled, so
+	//    every terminal event it will ever emit is buffered by the time this
+	//    returns.  The events channel is buffered to the queue depth, so emit
+	//    cannot block even with no reader currently scheduled.
+	c.worker.Stop()
+
+	// 2. Now the consumer.  Cancelling these stops the drain goroutine, the
+	//    health poller, and the lease keepalive.
+	//
+	//    Note for #83: leaderCancel used to run first, and because leaderCtx is
+	//    the worker's ctx that gave the in-flight transfer a cancellation path.
+	//    It no longer does — deliberately, since aborting the transfer is the
+	//    opposite of letting it settle.  Bounding a transfer against an
+	//    unresponsive site is #83's job and wants a real timeout; it was never
+	//    covered in the no-lease-manager case anyway, which is every shipped
+	//    deployment.  cmd/coordinator cancels the root context before calling
+	//    Close, so the transfer ctx is already done by the time Stop is entered.
 	if leaderCancel != nil {
 		leaderCancel()
 	}
@@ -484,7 +508,19 @@ func (c *Coordinator) Stop() {
 		storeCancel()
 	}
 	c.storeWg.Wait()
-	c.worker.Stop()
+
+	// 3. Final flush on this goroutine.  storeWg.Wait above guarantees the drain
+	//    goroutine has returned, so there is no concurrent reader.
+	//
+	//    Step 1 plus the drain's own flush covers the common case, but not the
+	//    one the shipped daemon actually produces: cmd/coordinator cancels the
+	//    root context and *then* calls Close, so the drain can already have
+	//    exited on ctx.Done before Stop is ever entered — and the same is true
+	//    after a lost leader lease, which cancels leaderCtx with no Stop
+	//    involved.  Flushing here makes the guarantee independent of who
+	//    cancelled what first, which is worth more than the one non-blocking
+	//    channel read it costs when the buffer is empty.
+	c.flushWorkerEvents(store)
 
 	// Release the leader lease last so a standby can take over quickly.
 	if l != nil {
@@ -1107,6 +1143,11 @@ func (c *Coordinator) recoverPendingJobs(ctx context.Context, store metadata.Sto
 // drainWorkerEvents processes replication job events.
 // It removes completed/failed jobs from the store (when set) and updates metrics.
 // Runs in a goroutine until ctx is cancelled.
+//
+// On cancellation it flushes whatever is already buffered before returning.
+// Exiting on the first ctx.Done would discard events the worker has already
+// emitted, which is the same loss #78 describes in a narrower window: the
+// buffered EventCompleted of a transfer that finished a moment before shutdown.
 func (c *Coordinator) drainWorkerEvents(ctx context.Context, store metadata.Store) {
 	for {
 		select {
@@ -1114,42 +1155,74 @@ func (c *Coordinator) drainWorkerEvents(ctx context.Context, store metadata.Stor
 			if !ok {
 				return
 			}
-			if ev.Type == replication.EventCompleted || ev.Type == replication.EventFailed {
-				if store != nil {
-					id := makeJobID(ev.Job.SourceSite.Name(), ev.Job.DestSite.Name(), ev.Job.Key)
-					// Use a fresh context: ctx may already be cancelled if
-					// Stop() fired while this event was being processed.
-					// A cancelled ctx would leave the job in the store and
-					// cause it to be re-enqueued on the next restart (#61).
-					deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 5*time.Second)
-					err := store.DeleteJob(deleteCtx, id)
-					deleteCancel()
-					if err != nil {
-						slog.Warn("coordinator: delete job from store", "job_id", id, "error", err)
-					}
-				}
-				// Record content hash on successful transfer for future
-				// coordinator-level dedup.
-				if store != nil && ev.Type == replication.EventCompleted && ev.ContentHash != "" {
-					recCtx, recCancel := context.WithTimeout(context.Background(), 5*time.Second)
-					recErr := store.PutReplicatedObject(recCtx, &metadata.ReplicatedObject{
-						Site:         ev.Job.DestSite.Name(),
-						Key:          ev.Job.Key,
-						ContentHash:  ev.ContentHash,
-						ReplicatedAt: time.Now(),
-					})
-					recCancel()
-					if recErr != nil {
-						slog.Warn("coordinator: record replicated object", "key", ev.Job.Key, "error", recErr)
-					}
-				}
-				if c.m != nil {
-					c.m.RecordReplication(string(ev.Type))
-					c.m.SetReplicationQueueDepth(c.worker.QueueDepth())
-				}
-			}
+			c.handleWorkerEvent(ev, store)
 		case <-ctx.Done():
+			c.flushWorkerEvents(store)
 			return
 		}
+	}
+}
+
+// flushWorkerEvents processes every event currently buffered in the worker's
+// events channel and returns as soon as it is empty.  It never blocks waiting
+// for an event that has not been emitted yet.
+//
+// Callers must ensure no other goroutine is reading Events() concurrently, or
+// the two will split the buffer between them.
+func (c *Coordinator) flushWorkerEvents(store metadata.Store) {
+	for {
+		select {
+		case ev, ok := <-c.worker.Events():
+			if !ok {
+				return
+			}
+			c.handleWorkerEvent(ev, store)
+		default:
+			return
+		}
+	}
+}
+
+// handleWorkerEvent applies one replication event to the store and to metrics.
+// Non-terminal events (EventStarted) are ignored.
+func (c *Coordinator) handleWorkerEvent(ev replication.ReplicationEvent, store metadata.Store) {
+	if ev.Type != replication.EventCompleted && ev.Type != replication.EventFailed {
+		return
+	}
+
+	if store != nil {
+		id := makeJobID(ev.Job.SourceSite.Name(), ev.Job.DestSite.Name(), ev.Job.Key)
+		// Use a fresh context: the drain's ctx may already be cancelled if
+		// Stop() fired while this event was being processed.  A cancelled ctx
+		// would leave the job in the store and cause it to be re-enqueued on
+		// the next restart (#61).
+		deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := store.DeleteJob(deleteCtx, id)
+		deleteCancel()
+		if err != nil {
+			slog.Warn("coordinator: delete job from store", "job_id", id, "error", err)
+		}
+	}
+	// Record content hash on successful transfer for future coordinator-level dedup.
+	if store != nil && ev.Type == replication.EventCompleted && ev.ContentHash != "" {
+		recCtx, recCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		recErr := store.PutReplicatedObject(recCtx, &metadata.ReplicatedObject{
+			Site:         ev.Job.DestSite.Name(),
+			Key:          ev.Job.Key,
+			ContentHash:  ev.ContentHash,
+			ReplicatedAt: time.Now(),
+		})
+		recCancel()
+		if recErr != nil {
+			slog.Warn("coordinator: record replicated object", "key", ev.Job.Key, "error", recErr)
+		}
+	}
+
+	c.mu.RLock()
+	m := c.m
+	c.mu.RUnlock()
+	if m != nil {
+		m.RecordReplication(string(ev.Type))
+		m.SetReplicationQueueDepth(c.worker.QueueDepth())
 	}
 }

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -79,6 +79,10 @@ type Coordinator struct {
 
 	// Read-through object cache (optional).
 	objCache *cache.Cache // nil = disabled
+
+	// enqueueBackpressure bounds how long Put waits for replication queue room.
+	// 0 → defaultEnqueueBackpressure.  Overridden in tests to keep them fast.
+	enqueueBackpressure time.Duration
 }
 
 // defaultHealthPollInterval is the cadence for background site health checks
@@ -106,6 +110,54 @@ const defaultHealthTimeout = 30 * time.Second
 //	errors.Is(err, coordinator.ErrNotFound)
 //	errors.Is(err, objectfssdk.ErrNotFound)
 var ErrNotFound = fmt.Errorf("object not found at any site: %w", objectfssdk.ErrNotFound)
+
+// ErrReplicationNotQueued reports that a Put stored the data on its primary
+// sites but could not queue replication to one or more secondaries, because the
+// replication queue was still full after the backpressure budget elapsed.
+//
+// A Put that returns an error wrapping this sentinel is a *partial success* and
+// must not be read as a failed write:
+//
+//   - The bytes are durably stored on every primary in the routed set.  A
+//     synchronous write failure returns a different error and never reaches
+//     this point.
+//   - Secondary sites named in the message do not have the data and no
+//     background work will deliver it, unless a metadata store is configured —
+//     in which case the persisted job is recovered on the next start.
+//
+// Retrying the identical Put is safe and is the intended response: the primary
+// write is idempotent and the coordinator-level dedup skips destinations that
+// already hold the content.
+//
+// The returned error also wraps the underlying cause — the worker's queue-full
+// error, or the context error if the caller's context ended while waiting for
+// room — so errors.Is finds both this sentinel and the reason.
+//
+// Before this existed, a full queue was logged at warn level and Put returned
+// nil, so callers were told a write was replicated when it was not — 31 of 40
+// Puts were dropped at the shipped defaults with every one reporting success
+// (#79).
+var ErrReplicationNotQueued = errors.New("replication not queued")
+
+// defaultEnqueueBackpressure is how long Put will wait for room in the
+// replication queue before giving up and reporting ErrReplicationNotQueued.
+//
+// It exists because the queue is much smaller than it looks and the worker is
+// serial: the shipped daemon passes Performance.MaxConcurrentTransfers (default
+// 8) to SetWorkerQueueDepth, so a burst of writes fills it almost immediately
+// even though each job takes only as long as one GET plus one PUT.  Waiting
+// briefly converts a burst into a queue rather than into data loss.
+//
+// The budget is deliberately short and deliberately finite.  Unbounded blocking
+// would make the async path synchronous under load and let one unreachable
+// destination stall every writer; returning immediately, as the code did before,
+// loses the write.  A couple of seconds spans a burst without hiding a genuine
+// backlog, which is what the error and the dropped counter are for.
+const defaultEnqueueBackpressure = 2 * time.Second
+
+// enqueueRetryInterval is the poll interval used while waiting for queue room.
+// The worker exposes no "room available" signal, so this polls Enqueue.
+const enqueueRetryInterval = 5 * time.Millisecond
 
 // isSiteFailure reports whether err is evidence that the site itself is unwell,
 // as opposed to an ordinary answer to an ordinary request.
@@ -276,12 +328,32 @@ func (c *Coordinator) SetLeaseTTL(d time.Duration) {
 // SetWorkerQueueDepth configures the replication worker queue depth.
 // Must be called before Start; has no effect if Start has already been called.
 // Pass 0 to retain the existing depth (default 512).
+//
+// Note that this is a *queue depth*, not a concurrency limit — the worker is a
+// single serial goroutine.  The shipped daemon passes
+// Performance.MaxConcurrentTransfers here, which conflates the two and is why
+// the effective queue is 8 rather than 512 at the defaults.  Renaming that
+// setting is a config change and belongs elsewhere; Put now applies
+// backpressure rather than dropping writes, so the small depth costs latency
+// under a burst instead of data (#79).
 func (c *Coordinator) SetWorkerQueueDepth(depth int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if depth > 0 {
 		c.worker = replication.NewWorker(depth)
 	}
+}
+
+// SetEnqueueBackpressure bounds how long Put waits for room in the replication
+// queue before returning an error wrapping ErrReplicationNotQueued.
+//
+// Pass 0 to use defaultEnqueueBackpressure (2 s).  A negative value disables
+// waiting entirely: Put attempts one Enqueue and reports the drop immediately.
+// May be called at any time; safe for concurrent use.
+func (c *Coordinator) SetEnqueueBackpressure(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.enqueueBackpressure = d
 }
 
 // SetCircuitBreaker registers a circuit breaker with the coordinator.
@@ -707,9 +779,25 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 // If the policy routes a write to a set with no primaries (e.g. a burst-only
 // rule), the first non-primary site is promoted to the synchronous write
 // target so data is durably stored before Put returns.
+//
+// # Replication backpressure
+//
+// If the replication queue is full, Put waits up to the backpressure budget
+// (see SetEnqueueBackpressure) for room.  If it is still full, Put returns an
+// error wrapping [ErrReplicationNotQueued] — a *partial success*: the data is
+// durably stored on the primaries but the named secondaries did not get a job.
+// Retrying the same Put is safe and is the intended response.  Callers that only
+// care about the primary write should test for that sentinel rather than
+// treating the error as a failed write (#79).
+//
+// An HTTP layer in front of this should map ErrReplicationNotQueued to 202
+// Accepted (the object exists; replication is incomplete), not to 5xx: the
+// object is retrievable immediately afterwards.  cmd/coordinator currently maps
+// every Put error to 502, which is wrong for this case and is tracked separately.
 func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 	c.mu.RLock()
 	snapshot, pol, store, cb, oc := c.snapshotSites(), c.policy, c.store, c.cb, c.objCache
+	m, backpressure := c.m, c.enqueueBackpressure
 	c.mu.RUnlock()
 
 	routed, err := pol.Route(policy.OperationWrite, key, snapshot)
@@ -742,6 +830,13 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 	// the worker can complete it.  If the order were reversed, a fast worker
 	// could complete the job and drainWorkerEvents could call DeleteJob before
 	// PutReplicationJob runs, leaving a phantom entry in the store.
+	// notQueued collects destinations whose replication job could not be queued,
+	// so Put can report them all rather than only the first or none at all.
+	// notQueuedCause keeps the first underlying reason (queue full, or the
+	// context error) so the caller can distinguish "we gave up waiting" from
+	// "you cancelled" with errors.Is.
+	var notQueued []string
+	var notQueuedCause error
 	if len(primaries) > 0 {
 		src := primaries[0]
 		// Compute content hash once for coordinator-level dedup below.
@@ -773,23 +868,82 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 					continue
 				}
 			}
-			if enqErr := c.worker.Enqueue(replication.ReplicationJob{
+			if enqErr := c.enqueueWithBackpressure(ctx, backpressure, replication.ReplicationJob{
 				SourceSite: src,
 				DestSite:   s,
 				Key:        key,
 				Size:       int64(len(data)),
 			}); enqErr != nil {
-				slog.Warn("coordinator: Put enqueue async replication", "key", key, "dest", s.Name(), "error", enqErr)
+				// The job stays in the store when one is configured, so a restart
+				// recovers it.  With no store — every shipped deployment today —
+				// the write is simply not replicated, which is why this is an
+				// error to the caller and a counter rather than a log line.
+				m.RecordReplicationDropped()
+				slog.Error("coordinator: replication queue full; write not replicated",
+					"key", key, "dest", s.Name(), "queue_depth", c.worker.QueueDepth(), "error", enqErr)
+				notQueued = append(notQueued, s.Name())
+				if notQueuedCause == nil {
+					notQueuedCause = enqErr
+				}
+				// A dead context will not recover for any later destination, and
+				// polling each one for the full budget would multiply the delay.
+				if ctx.Err() != nil {
+					break
+				}
 			}
 		}
 	}
 
 	// Invalidate the cache so the next Get fetches the freshly-written value.
+	// Done before the partial-success return: the primary write happened, so a
+	// cached copy of the old value is stale either way.
 	if oc != nil {
 		oc.Delete(key)
 		c.metricsCacheBytes(oc.Stats().Bytes)
 	}
+
+	if len(notQueued) > 0 {
+		return fmt.Errorf("coordinator: Put %q: stored on primaries but %w for %v: %w",
+			key, ErrReplicationNotQueued, notQueued, notQueuedCause)
+	}
 	return nil
+}
+
+// enqueueWithBackpressure submits job to the replication worker, waiting up to
+// budget for queue room.  A budget of 0 means defaultEnqueueBackpressure; a
+// negative budget means a single attempt with no wait.
+//
+// Returns nil once the job is queued, or the worker's queue-full error if the
+// budget elapses.  A cancelled ctx aborts the wait and returns ctx.Err().
+func (c *Coordinator) enqueueWithBackpressure(ctx context.Context, budget time.Duration, job replication.ReplicationJob) error {
+	err := c.worker.Enqueue(job)
+	if err == nil || budget < 0 {
+		return err
+	}
+	if budget == 0 {
+		budget = defaultEnqueueBackpressure
+	}
+
+	// The queue is full.  Poll for room: the worker exposes no readiness signal,
+	// and a job leaves the queue as soon as the serial worker picks it up, so the
+	// wait is usually one transfer long rather than the whole budget.
+	deadline := time.NewTimer(budget)
+	defer deadline.Stop()
+	ticker := time.NewTicker(enqueueRetryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return err // the last queue-full error
+		case <-ticker.C:
+			if err = c.worker.Enqueue(job); err == nil {
+				return nil
+			}
+		}
+	}
 }
 
 // Delete removes the object at key from sites in the policy-routed set.

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -25,12 +25,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
+	objectfserrors "github.com/scttfrdmn/objectfs/pkg/errors"
 	objectfstypes "github.com/scttfrdmn/objectfs/pkg/types"
+	objectfssdk "github.com/scttfrdmn/objectfs/sdks/go/objectfs"
 
 	"github.com/scttfrdmn/globalfs/internal/cache"
 	"github.com/scttfrdmn/globalfs/internal/circuitbreaker"
@@ -88,6 +91,76 @@ const defaultLeaseTTL = 15 * time.Second
 // defaultHealthTimeout is the maximum duration Health waits for all goroutines
 // when the caller supplies a context without a deadline.
 const defaultHealthTimeout = 30 * time.Second
+
+// ErrNotFound reports that an object does not exist at any of the routed sites.
+//
+// Get and Head return an error wrapping this sentinel when every site they
+// tried answered "no such key", as opposed to failing to answer at all.  The
+// distinction matters to callers: "absent" is a normal answer that deserves a
+// 404, while "every site errored" is a 502.  Before this existed the two were
+// indistinguishable (#77).
+//
+// It wraps [objectfssdk.ErrNotFound], so both of these hold for the error
+// returned by Get:
+//
+//	errors.Is(err, coordinator.ErrNotFound)
+//	errors.Is(err, objectfssdk.ErrNotFound)
+var ErrNotFound = fmt.Errorf("object not found at any site: %w", objectfssdk.ErrNotFound)
+
+// isSiteFailure reports whether err is evidence that the site itself is unwell,
+// as opposed to an ordinary answer to an ordinary request.
+//
+// The circuit breaker needs this distinction and cannot make it from the fact
+// that an error occurred.  A missing key means the site is up, reachable,
+// authenticating and answering correctly — counting it as a failure is how five
+// lookups of absent keys ejected a healthy site from routing for the whole
+// cooldown (#77).
+//
+// The authority is objectfs's [objectfserrors.IsServiceFailure], the same
+// function objectfs's own health tracker and circuit breaker consult, so
+// GlobalFS cannot drift from the classification objectfs makes one layer down.
+// It matches on the error *code*, so a backend error wrapped several times over
+// still resolves.
+//
+// An error carrying no objectfs code counts as a failure.  That direction is
+// deliberate and matches objectfs: the failure mode of misclassifying something
+// unknown is a breaker that opens too eagerly and recovers on its cooldown, not
+// one that never notices an outage.
+func isSiteFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// A caller who withdrew the request says nothing about the site.  objectfs
+	// classifies this as ErrCodeOperationCanceled (not a failure), but GlobalFS
+	// produces the bare context error itself — retry.Do returns ctx.Err()
+	// directly — so it arrives without an objectfs code and has to be named here.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	var objErr *objectfserrors.ObjectFSError
+	if errors.As(err, &objErr) {
+		return objectfserrors.IsServiceFailure(objErr.Code)
+	}
+	return true
+}
+
+// recordSiteResult updates the circuit breaker for one site attempt.
+//
+// A non-failure error records a *success*: the site was reached and it answered,
+// which is exactly what the breaker is trying to measure.  This mirrors
+// objectfs's defaultIsSuccessful.  No-op when cb is nil.
+func recordSiteResult(cb *circuitbreaker.Breaker, name string, err error) {
+	if cb == nil {
+		return
+	}
+	if isSiteFailure(err) {
+		cb.RecordFailure(name)
+		return
+	}
+	cb.RecordSuccess(name)
+}
 
 // ── Metrics helpers ───────────────────────────────────────────────────────────
 // These wrappers centralise the nil check so call sites stay clean.
@@ -216,6 +289,9 @@ func (c *Coordinator) SetWorkerQueueDepth(depth int) {
 // When set, sites whose circuit is open are skipped during read routing (Get,
 // Head).  Write operations (Put, Delete) always target their designated sites
 // but record success/failure to keep the breaker state current.
+//
+// Only errors that are evidence the site itself is unwell count as failures;
+// see isSiteFailure.  A missing key is an ordinary answer and records a success.
 //
 // If all circuits are open the breaker is bypassed so callers are never
 // completely blocked by a stale circuit state.  Pass nil to disable circuit
@@ -519,6 +595,10 @@ func (c *Coordinator) Health(ctx context.Context) map[string]error {
 // The policy engine determines site order; healthy sites (from the background
 // health cache) are then promoted to the front of that list so degraded sites
 // are only tried as a fallback.  The first successful read is returned.
+//
+// When every site tried answered "no such key", the returned error wraps
+// [ErrNotFound].  Callers should test for that before treating a failure as an
+// outage; a missing object is an answer, not a failure (#77).
 func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 	c.mu.RLock()
 	snapshot, pol, cb, retryCfg, oc := c.snapshotSites(), c.policy, c.cb, c.retryConfig, c.objCache
@@ -547,6 +627,10 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 	ordered = filterByCircuitBreaker(cb, ordered)
 
 	var lastErr error
+	// allNotFound stays true while every site tried has answered "no such key".
+	// It distinguishes "the object does not exist" from "no site could answer",
+	// which the API layer needs to tell a 404 from a 502 (#77).
+	allNotFound := true
 	for _, s := range ordered {
 		var data []byte
 		siteErr := doWithRetry(ctx, retryCfg, func() error {
@@ -554,12 +638,9 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 			data, err = s.Get(ctx, key, 0, 0)
 			return err
 		})
-		if cb != nil {
-			if siteErr == nil {
-				cb.RecordSuccess(s.Name())
-			} else {
-				cb.RecordFailure(s.Name())
-			}
+		recordSiteResult(cb, s.Name(), siteErr)
+		if siteErr != nil && !errors.Is(siteErr, objectfssdk.ErrNotFound) {
+			allNotFound = false
 		}
 		if siteErr == nil {
 			// Populate cache on successful site fetch.
@@ -573,6 +654,9 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 			return data, nil
 		}
 		lastErr = siteErr
+	}
+	if allNotFound {
+		return nil, fmt.Errorf("coordinator: Get %q: %w", key, ErrNotFound)
 	}
 	return nil, fmt.Errorf("coordinator: Get %q failed on all sites: %w", key, lastErr)
 }
@@ -609,14 +693,10 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 
 	for _, s := range primaries {
 		if err := s.Put(ctx, key, data); err != nil {
-			if cb != nil {
-				cb.RecordFailure(s.Name())
-			}
+			recordSiteResult(cb, s.Name(), err)
 			return fmt.Errorf("coordinator: Put %q to %q: %w", key, s.Name(), err)
 		}
-		if cb != nil {
-			cb.RecordSuccess(s.Name())
-		}
+		recordSiteResult(cb, s.Name(), nil)
 	}
 
 	// Enqueue async replication to remaining sites using the first primary
@@ -695,23 +775,16 @@ func (c *Coordinator) Delete(ctx context.Context, key string) error {
 
 	for _, s := range primaries {
 		if err := s.Delete(ctx, key); err != nil {
-			if cb != nil {
-				cb.RecordFailure(s.Name())
-			}
+			recordSiteResult(cb, s.Name(), err)
 			return fmt.Errorf("coordinator: Delete %q from primary %q: %w", key, s.Name(), err)
 		}
-		if cb != nil {
-			cb.RecordSuccess(s.Name())
-		}
+		recordSiteResult(cb, s.Name(), nil)
 	}
 	for _, s := range others {
-		if err := s.Delete(ctx, key); err != nil {
-			if cb != nil {
-				cb.RecordFailure(s.Name())
-			}
+		err := s.Delete(ctx, key)
+		recordSiteResult(cb, s.Name(), err)
+		if err != nil {
 			slog.Warn("coordinator: Delete from non-primary site", "key", key, "site", s.Name(), "error", err)
-		} else if cb != nil {
-			cb.RecordSuccess(s.Name())
 		}
 	}
 
@@ -755,6 +828,9 @@ func (c *Coordinator) List(ctx context.Context, prefix string, limit int) ([]obj
 // Head returns metadata for the object at key.
 // Sites are checked in policy-routed order with healthy sites promoted to the
 // front (same health-aware reordering as Get).  The first hit is returned.
+//
+// As with Get, the returned error wraps [ErrNotFound] when every site answered
+// "no such key" rather than failing to answer.
 func (c *Coordinator) Head(ctx context.Context, key string) (*objectfstypes.ObjectInfo, error) {
 	c.mu.RLock()
 	snapshot, pol, cb, retryCfg := c.snapshotSites(), c.policy, c.cb, c.retryConfig
@@ -773,6 +849,7 @@ func (c *Coordinator) Head(ctx context.Context, key string) (*objectfstypes.Obje
 	ordered = filterByCircuitBreaker(cb, ordered)
 
 	var lastErr error
+	allNotFound := true
 	for _, s := range ordered {
 		var info *objectfstypes.ObjectInfo
 		siteErr := doWithRetry(ctx, retryCfg, func() error {
@@ -780,17 +857,17 @@ func (c *Coordinator) Head(ctx context.Context, key string) (*objectfstypes.Obje
 			info, err = s.Head(ctx, key)
 			return err
 		})
-		if cb != nil {
-			if siteErr == nil {
-				cb.RecordSuccess(s.Name())
-			} else {
-				cb.RecordFailure(s.Name())
-			}
+		recordSiteResult(cb, s.Name(), siteErr)
+		if siteErr != nil && !errors.Is(siteErr, objectfssdk.ErrNotFound) {
+			allNotFound = false
 		}
 		if siteErr == nil {
 			return info, nil
 		}
 		lastErr = siteErr
+	}
+	if allNotFound {
+		return nil, fmt.Errorf("coordinator: Head %q: %w", key, ErrNotFound)
 	}
 	return nil, fmt.Errorf("coordinator: Head %q failed on all sites: %w", key, lastErr)
 }
@@ -921,11 +998,35 @@ func preferHealthySites(sites []*site.SiteMount, report map[string]error) []*sit
 // doWithRetry calls fn once when cfg is nil, or delegates to retry.Do when a
 // retry configuration is set.  This keeps the call sites readable and avoids
 // a nil-pointer dereference on the config.
+//
+// A "no such key" answer is never retried.  It is not transient: the site
+// answered, and it will answer the same way three times.  Retrying cost three
+// round trips and two backoff sleeps per absent key before #77 was fixed.
+//
+// Other error classes are still retried even when isSiteFailure says they are
+// not the site's fault.  Retryable and service-failure are separate questions
+// — objectfs makes the same split — and only not-found is unambiguously
+// pointless to repeat.
 func doWithRetry(ctx context.Context, cfg *retry.Config, fn func() error) error {
 	if cfg == nil {
 		return fn()
 	}
-	return retry.Do(ctx, *cfg, fn)
+	// retry.Do has no early-exit hook, so a terminal error is stashed here and
+	// the wrapper reports nil to break the loop.  The stashed error is what the
+	// caller sees, so the "success" is never observable outside this function.
+	var terminal error
+	err := retry.Do(ctx, *cfg, func() error {
+		fnErr := fn()
+		if fnErr != nil && errors.Is(fnErr, objectfssdk.ErrNotFound) {
+			terminal = fnErr
+			return nil
+		}
+		return fnErr
+	})
+	if terminal != nil {
+		return terminal
+	}
+	return err
 }
 
 // filterByCircuitBreaker returns a filtered subset of sites whose circuits

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	objectfserrors "github.com/scttfrdmn/objectfs/pkg/errors"
 	objectfstypes "github.com/scttfrdmn/objectfs/pkg/types"
 	objectfssdk "github.com/scttfrdmn/objectfs/sdks/go/objectfs"
@@ -16,6 +17,7 @@ import (
 	"github.com/scttfrdmn/globalfs/internal/circuitbreaker"
 	"github.com/scttfrdmn/globalfs/internal/lease"
 	"github.com/scttfrdmn/globalfs/internal/metadata"
+	"github.com/scttfrdmn/globalfs/internal/metrics"
 	"github.com/scttfrdmn/globalfs/internal/policy"
 	"github.com/scttfrdmn/globalfs/internal/retry"
 	"github.com/scttfrdmn/globalfs/pkg/site"
@@ -881,6 +883,301 @@ type failingPutJobStore struct {
 
 func (f *failingPutJobStore) PutReplicationJob(_ context.Context, _ *metadata.ReplicationJob) error {
 	return errors.New("simulated storage failure")
+}
+
+// ─── Full replication queue (#79) ─────────────────────────────────────────────
+
+// TestCoordinator_Put_FullQueueDoesNotReportSuccess is the core #79 assertion:
+// a write whose replication was not queued must not be reported as replicated.
+// Before the fix, 40 sequential Puts at the shipped defaults all returned nil
+// and 9 reached the backup.
+func TestCoordinator_Put_FullQueueDoesNotReportSuccess(t *testing.T) {
+	t.Parallel()
+
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Park the worker inside the destination Put so nothing ever drains the
+	// queue: whatever depth it has, it fills and stays full.
+	release := backupClient.blockPuts()
+	defer release()
+
+	const depth = 2
+	c := New(primary, backup)
+	c.SetWorkerQueueDepth(depth)
+	// Keep the test quick; the default 2 s budget × N Puts is not worth waiting for.
+	c.SetEnqueueBackpressure(50 * time.Millisecond)
+	c.Start(ctx)
+	// LIFO: release the blocked transfer before Stop, or Stop parks on a worker
+	// inside Put and the test hangs instead of failing (#83).
+	defer c.Stop()
+	defer release()
+
+	const total = 12
+	var dropped, ok int
+	for i := 0; i < total; i++ {
+		err := c.Put(ctx, fmt.Sprintf("obj-%02d", i), []byte("payload"))
+		switch {
+		case err == nil:
+			ok++
+		case errors.Is(err, ErrReplicationNotQueued):
+			dropped++
+		default:
+			t.Fatalf("Put %d: unexpected error: %v", i, err)
+		}
+	}
+
+	if dropped == 0 {
+		t.Fatalf("all %d Puts reported success with a permanently full queue of depth %d; "+
+			"the caller was told writes were replicated when they were not", total, depth)
+	}
+
+	// Every Put still stored the data on the primary — that is the whole point of
+	// calling it a partial success rather than a failure.
+	if got := len(primaryClient.keys()); got != total {
+		t.Errorf("primary holds %d keys, want %d — the synchronous write must always land", got, total)
+	}
+
+	t.Logf("depth=%d: %d Puts queued, %d reported ErrReplicationNotQueued", depth, ok, dropped)
+}
+
+// TestCoordinator_Put_ErrReplicationNotQueuedIsDistinguishable verifies that the
+// partial-success error is separable from a genuine write failure.  A caller
+// that cannot tell them apart cannot decide whether to retry or to alarm.
+func TestCoordinator_Put_ErrReplicationNotQueuedIsDistinguishable(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := backupClient.blockPuts()
+	defer release()
+
+	c := New(primary, backup)
+	c.SetWorkerQueueDepth(1)
+	c.SetEnqueueBackpressure(-1) // no waiting: fail the first full Enqueue
+	c.Start(ctx)
+	defer c.Stop()
+	defer release()
+
+	// First Put fills the queue (depth 1); the worker takes it and parks in Put.
+	if err := c.Put(ctx, "a", []byte("x")); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	// Keep going until one is refused — the worker may have dequeued the first.
+	var partial error
+	for i := 0; i < 10 && partial == nil; i++ {
+		if err := c.Put(ctx, fmt.Sprintf("b-%d", i), []byte("x")); err != nil {
+			partial = err
+		}
+	}
+	if partial == nil {
+		t.Fatal("no Put was refused with a full queue and no backpressure budget")
+	}
+	if !errors.Is(partial, ErrReplicationNotQueued) {
+		t.Errorf("full queue: expected ErrReplicationNotQueued, got %v", partial)
+	}
+	// It must not masquerade as a not-found or any other coordinator condition.
+	if errors.Is(partial, ErrNotFound) {
+		t.Errorf("full queue error should not wrap ErrNotFound: %v", partial)
+	}
+
+	// A genuine primary write failure is a different error entirely.
+	badPrimary := site.New("bad", types.SiteRolePrimary,
+		&memClient{putErr: errors.New("disk full"), objects: map[string][]byte{}})
+	writeErr := New(badPrimary).Put(ctx, "k", []byte("x"))
+	if writeErr == nil {
+		t.Fatal("expected an error when the primary write fails")
+	}
+	if errors.Is(writeErr, ErrReplicationNotQueued) {
+		t.Errorf("a failed primary write must not report ErrReplicationNotQueued: %v", writeErr)
+	}
+}
+
+// TestCoordinator_Put_BackpressureWaitsForRoom verifies the preferred behaviour:
+// a transient full queue is absorbed by waiting, not turned into an error.  A
+// burst against a depth-1 queue should be fully replicated.
+func TestCoordinator_Put_BackpressureWaitsForRoom(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := New(primary, backup)
+	c.SetWorkerQueueDepth(1) // pathologically small; the worker drains it fast
+	c.Start(ctx)
+	defer c.Stop()
+
+	const total = 20
+	for i := 0; i < total; i++ {
+		if err := c.Put(ctx, fmt.Sprintf("burst-%02d", i), []byte("payload")); err != nil {
+			t.Fatalf("Put %d: queue room should have been waited for, got %v", i, err)
+		}
+	}
+
+	// Every write should reach the backup; nothing was dropped.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(backupClient.keys()) == total {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("backup holds %d of %d objects — a burst was silently dropped", len(backupClient.keys()), total)
+}
+
+// TestCoordinator_Put_BackpressureRespectsContextCancellation verifies the wait
+// is abortable.  An unbounded or uncancellable wait would let one wedged
+// destination stall every writer, which is the reason the budget is finite.
+func TestCoordinator_Put_BackpressureRespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	startCtx, startCancel := context.WithCancel(context.Background())
+	defer startCancel()
+
+	release := backupClient.blockPuts()
+	defer release()
+
+	c := New(primary, backup)
+	c.SetWorkerQueueDepth(1)
+	c.SetEnqueueBackpressure(time.Hour) // would hang without cancellation
+	c.Start(startCtx)
+	defer c.Stop()
+	defer release()
+
+	if err := c.Put(startCtx, "fill", []byte("x")); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+
+	putCtx, putCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer putCancel()
+
+	done := make(chan error, 1)
+	go func() {
+		var err error
+		// Keep writing until one blocks on the full queue and the ctx expires.
+		for i := 0; i < 10; i++ {
+			if err = c.Put(putCtx, fmt.Sprintf("blocked-%d", i), []byte("x")); err != nil {
+				break
+			}
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a Put to fail once the context expired")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("expected the context error to propagate, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Put did not honour context cancellation while waiting for queue room")
+	}
+}
+
+// TestCoordinator_Put_FullQueueIncrementsDroppedCounter verifies the drop is
+// observable.  The queue-depth gauge cannot serve: it only updates on job
+// settle, and it reads zero again once the backlog clears.
+func TestCoordinator_Put_FullQueueIncrementsDroppedCounter(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := backupClient.blockPuts()
+	defer release()
+
+	reg := prometheus.NewRegistry()
+	c := New(primary, backup)
+	c.SetMetrics(metrics.New(reg))
+	c.SetWorkerQueueDepth(1)
+	c.SetEnqueueBackpressure(-1)
+	c.Start(ctx)
+	defer c.Stop()
+	defer release()
+
+	for i := 0; i < 10; i++ {
+		_ = c.Put(ctx, fmt.Sprintf("k-%d", i), []byte("x"))
+	}
+
+	got := counterValue(t, reg, "globalfs_replication_dropped_total")
+	if got == 0 {
+		t.Error("globalfs_replication_dropped_total is 0 after dropped enqueues — " +
+			"a queue that discards writes has to be observable")
+	}
+	t.Logf("globalfs_replication_dropped_total = %v", got)
+}
+
+// counterValue reads a single unlabelled counter out of a registry.
+func counterValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, mtc := range f.GetMetric() {
+			return mtc.GetCounter().GetValue()
+		}
+	}
+	t.Fatalf("metric %q not found in registry", name)
+	return 0
+}
+
+// TestCoordinator_Put_NoStore_FullQueueStillReports covers the shipped
+// configuration: no metadata store, so nothing recovers a dropped job and the
+// error to the caller is the only signal that exists.
+func TestCoordinator_Put_NoStore_FullQueueStillReports(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := backupClient.blockPuts()
+	defer release()
+
+	c := New(primary, backup) // no SetStore
+	c.SetWorkerQueueDepth(1)
+	c.SetEnqueueBackpressure(-1)
+	c.Start(ctx)
+	defer c.Stop()
+	defer release()
+
+	var sawError bool
+	for i := 0; i < 10; i++ {
+		if err := c.Put(ctx, fmt.Sprintf("k-%d", i), []byte("x")); err != nil {
+			if !errors.Is(err, ErrReplicationNotQueued) {
+				t.Fatalf("Put: unexpected error: %v", err)
+			}
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Error("with no store and a full queue, Put reported success for an unreplicated write")
+	}
 }
 
 // ─── Shutdown while busy (#78) ────────────────────────────────────────────────

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -40,6 +40,11 @@ type memClient struct {
 	// the transfer held open; without it the worker and the drain goroutine can
 	// run to completion before the assertion executes.
 	putGate chan struct{}
+	// putsEntered counts calls that have reached the gate.  A test that wants to
+	// act *while* a transfer is in flight has to know the transfer has actually
+	// started, and polling the destination for the key cannot tell it — the key
+	// only appears once the gate is released.
+	putsEntered int
 }
 
 func newMemClient(objs map[string][]byte) *memClient {
@@ -85,6 +90,7 @@ func (m *memClient) Put(_ context.Context, key string, data []byte) error {
 	// m.mu would deadlock any concurrent hasKey/keys call.
 	m.mu.Lock()
 	gate := m.putGate
+	m.putsEntered++
 	m.mu.Unlock()
 	if gate != nil {
 		<-gate
@@ -176,6 +182,23 @@ func (m *memClient) blockPuts() (release func()) {
 	m.mu.Unlock()
 	var once sync.Once
 	return func() { once.Do(func() { close(gate) }) }
+}
+
+// waitForPut blocks until at least n Put calls have reached the gate, or the
+// timeout elapses (reported as a fatal test failure).
+func (m *memClient) waitForPut(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		entered := m.putsEntered
+		m.mu.Unlock()
+		if entered >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("no Put reached the client within %v — the transfer never started", timeout)
 }
 
 func makeMount(name string, role types.SiteRole, objs map[string][]byte) (*site.SiteMount, *memClient) {
@@ -858,6 +881,162 @@ type failingPutJobStore struct {
 
 func (f *failingPutJobStore) PutReplicationJob(_ context.Context, _ *metadata.ReplicationJob) error {
 	return errors.New("simulated storage failure")
+}
+
+// ─── Shutdown while busy (#78) ────────────────────────────────────────────────
+
+// TestCoordinator_Stop_WhileTransferInFlight_SettlesTheJob is the test the suite
+// did not have: Stop() against a coordinator with a transfer genuinely in
+// flight.  Before #78, Stop() cancelled the event drain and only then called
+// worker.Stop(), so the EventCompleted the finishing transfer emitted had no
+// reader — the job stayed in the store as a phantom to be re-enqueued on the
+// next boot, and the v0.2.0 dedup hash was lost.
+func TestCoordinator_Stop_WhileTransferInFlight_SettlesTheJob(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Hold the destination write open so the transfer is still running when
+	// Stop() is entered.
+	release := backupClient.blockPuts()
+	defer release() // safety net: never leave the worker parked if we fail early
+
+	store := metadata.NewMemoryStore()
+	c := New(primary, backup)
+	c.SetStore(store)
+	c.Start(ctx)
+
+	const key = "data/sample.bam"
+	if err := c.Put(ctx, key, []byte("genome")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// The transfer must actually have begun, otherwise this test would pass
+	// against the buggy ordering by shutting down before there was any event.
+	backupClient.waitForPut(t, 1, 2*time.Second)
+
+	// Stop() runs on its own goroutine because it blocks on the in-flight
+	// transfer, and the transfer cannot finish until this goroutine releases it.
+	stopped := make(chan struct{})
+	go func() {
+		c.Stop()
+		close(stopped)
+	}()
+
+	// Let Stop() get as far as it can, then let the transfer complete.  This is
+	// the SIGTERM-mid-transfer case: the shutdown is under way and the transfer
+	// then succeeds.
+	time.Sleep(50 * time.Millisecond)
+	release()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return within 5s")
+	}
+
+	// The transfer succeeded, so the object is at the destination.
+	if !backupClient.hasKey(key) {
+		t.Fatal("backup did not receive the object — the transfer did not complete")
+	}
+
+	// Terminal event must have been consumed: no phantom job left behind.
+	jobs, err := store.GetPendingJobs(ctx)
+	if err != nil {
+		t.Fatalf("GetPendingJobs: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Errorf("store has %d pending job(s) after Stop; the completion event was lost, "+
+			"so this job would be re-enqueued and the object transferred again: %v", len(jobs), jobs)
+	}
+
+	// ...and the dedup hash must have been recorded.
+	rec, err := store.GetReplicatedObject(ctx, "backup", key)
+	if err != nil {
+		t.Fatalf("GetReplicatedObject: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("no ReplicatedObject recorded for backup/" + key +
+			"; the content-hash index now disagrees with reality")
+	}
+	if rec.ContentHash == "" {
+		t.Error("ReplicatedObject recorded with an empty ContentHash")
+	}
+}
+
+// TestCoordinator_Stop_DrainFlushesBufferedEvents covers the narrower window
+// that ordering alone does not close: an event already emitted and sitting in
+// the buffer when the drain's context is cancelled.  The shipped daemon produces
+// exactly this — cmd/coordinator cancels the root context and then calls Close,
+// so the drain can be gone before Stop is entered.
+func TestCoordinator_Stop_DrainFlushesBufferedEvents(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := backupClient.blockPuts()
+	defer release()
+
+	store := metadata.NewMemoryStore()
+	c := New(primary, backup)
+	c.SetStore(store)
+	c.Start(ctx)
+
+	const key = "reads.fastq"
+	if err := c.Put(ctx, key, []byte("sequence")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	backupClient.waitForPut(t, 1, 2*time.Second)
+
+	// Kill the drain goroutine first, the way the daemon does, and only then
+	// release the transfer.  The completion event is emitted into a buffer with
+	// no live reader; Stop's final flush is the only thing that can consume it.
+	cancel()
+	// Wait for the drain and the health poller to observe the cancellation.
+	c.storeWg.Wait()
+	release()
+
+	c.Stop()
+
+	jobs, err := store.GetPendingJobs(ctx)
+	if err != nil {
+		t.Fatalf("GetPendingJobs: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Errorf("store has %d pending job(s); a buffered terminal event went unread: %v", len(jobs), jobs)
+	}
+	if rec, _ := store.GetReplicatedObject(context.Background(), "backup", key); rec == nil {
+		t.Error("dedup hash not recorded from the buffered completion event")
+	}
+}
+
+// TestCoordinator_Stop_BeforeStart guards the ordering change against the
+// Stop-before-Start path (tracked separately as #84): worker.Stop() now runs
+// first, on a worker that was never started.
+func TestCoordinator_Stop_BeforeStart(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(primary)
+
+	done := make(chan struct{})
+	go func() {
+		c.Stop() // must not panic and must not block
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() before Start() did not return within 2s")
+	}
 }
 
 // ─── Lease manager tests ──────────────────────────────────────────────────────

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -47,6 +47,9 @@ type memClient struct {
 	// started, and polling the destination for the key cannot tell it — the key
 	// only appears once the gate is released.
 	putsEntered int
+	// closes counts Close calls, so tests can assert that removing a site
+	// releases exactly the resources it took (#80).
+	closes int
 }
 
 func newMemClient(objs map[string][]byte) *memClient {
@@ -167,7 +170,22 @@ func (m *memClient) Health(_ context.Context) error {
 	defer m.mu.Unlock()
 	return m.healthErr
 }
-func (m *memClient) Close() error { return nil }
+
+func (m *memClient) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closes++
+	return nil
+}
+
+// closeCount reports how many times Close has been called.  Site removal must
+// close exactly what it removed: an unclosed SiteMount leaks a connection pool,
+// and closing one twice would be a double-free of the same pool.
+func (m *memClient) closeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closes
+}
 
 func (m *memClient) setHealthErr(err error) {
 	m.mu.Lock()
@@ -457,6 +475,181 @@ func TestCoordinator_AddRemoveSite(t *testing.T) {
 	sites := c.Sites()
 	if len(sites) != 1 || sites[0].Name() != "b" {
 		t.Errorf("expected only site \"b\" after RemoveSite(\"a\"), got %v", sites)
+	}
+}
+
+// ─── Site removal with duplicate names (#80) ──────────────────────────────────
+
+// TestCoordinator_RemoveSite_DuplicateNamesRemovesExactlyOne is the core #80
+// assertion.  Before the fix, one RemoveSite call filtered out every match while
+// keeping only the last, so a coordinator with two sites named "primary" was
+// emptied by a single call and only one of the two was closed.
+func TestCoordinator_RemoveSite_DuplicateNamesRemovesExactlyOne(t *testing.T) {
+	t.Parallel()
+
+	first, firstClient := makeMount("primary", types.SiteRolePrimary, nil)
+	second, secondClient := makeMount("primary", types.SiteRolePrimary, nil)
+	other, otherClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	c := New(first, second, other)
+
+	if !c.RemoveSite("primary") {
+		t.Fatal("RemoveSite(\"primary\"): reported not found")
+	}
+
+	sites := c.Sites()
+	if len(sites) != 2 {
+		t.Fatalf("after one RemoveSite the coordinator holds %d sites, want 2 — "+
+			"a single call removed more than it was asked to; sites=%v", len(sites), siteNames(sites))
+	}
+	// The highest-priority match goes; the duplicate and the unrelated site stay.
+	if got := siteNames(sites); got[0] != "primary" || got[1] != "backup" {
+		t.Errorf("remaining sites = %v, want [primary backup]", got)
+	}
+	if sites[0] != second {
+		t.Error("the wrong duplicate was kept: removal should take the highest-priority match")
+	}
+
+	// Whatever was removed must be closed, and nothing else may be.
+	if got := firstClient.closeCount(); got != 1 {
+		t.Errorf("removed site closed %d times, want 1 — an unclosed SiteMount leaks its connection pool", got)
+	}
+	if got := secondClient.closeCount(); got != 0 {
+		t.Errorf("retained duplicate was closed %d times, want 0 — it is still in the routing set", got)
+	}
+	if got := otherClient.closeCount(); got != 0 {
+		t.Errorf("unrelated site was closed %d times, want 0", got)
+	}
+
+	// A second call takes the duplicate, so the state is still reachable.
+	if !c.RemoveSite("primary") {
+		t.Fatal("second RemoveSite(\"primary\"): reported not found")
+	}
+	if got := siteNames(c.Sites()); len(got) != 1 || got[0] != "backup" {
+		t.Errorf("after the second removal sites = %v, want [backup]", got)
+	}
+	if got := secondClient.closeCount(); got != 1 {
+		t.Errorf("duplicate closed %d times after its own removal, want 1", got)
+	}
+	if got := firstClient.closeCount(); got != 1 {
+		t.Errorf("first site closed %d times, want 1 — no double close", got)
+	}
+}
+
+// TestCoordinator_RemoveSite_ClosesTheSiteItRemoved covers the ordinary
+// unique-name case: removal is not just a list edit, it must release the
+// connection pool (#62).
+func TestCoordinator_RemoveSite_ClosesTheSiteItRemoved(t *testing.T) {
+	t.Parallel()
+
+	a, aClient := makeMount("a", types.SiteRolePrimary, nil)
+	b, bClient := makeMount("b", types.SiteRoleBackup, nil)
+	c := New(a, b)
+
+	if !c.RemoveSite("a") {
+		t.Fatal("RemoveSite(\"a\"): reported not found")
+	}
+	if got := aClient.closeCount(); got != 1 {
+		t.Errorf("removed site closed %d times, want 1", got)
+	}
+	if got := bClient.closeCount(); got != 0 {
+		t.Errorf("retained site closed %d times, want 0", got)
+	}
+
+	// A miss must not close anything.
+	if c.RemoveSite("nope") {
+		t.Error("RemoveSite(\"nope\"): reported a removal that did not happen")
+	}
+	if got := bClient.closeCount(); got != 0 {
+		t.Errorf("after a miss, retained site closed %d times, want 0", got)
+	}
+}
+
+// TestCoordinator_RemoveSite_ReplacesNamespaceView verifies the merged view is
+// rebuilt, not just the site slice: a removed site must stop answering List.
+func TestCoordinator_RemoveSite_ReplacesNamespaceView(t *testing.T) {
+	t.Parallel()
+
+	a, _ := makeMount("a", types.SiteRolePrimary, map[string][]byte{"only-on-a": []byte("x")})
+	b, _ := makeMount("b", types.SiteRoleBackup, map[string][]byte{"only-on-b": []byte("y")})
+	c := New(a, b)
+
+	if !c.RemoveSite("a") {
+		t.Fatal("RemoveSite(\"a\"): reported not found")
+	}
+	items, err := c.List(context.Background(), "", 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, it := range items {
+		if it.Key == "only-on-a" {
+			t.Error("a removed site still contributes to List — the namespace view was not rebuilt")
+		}
+	}
+}
+
+// TestCoordinator_AddSiteUnique_RejectsDuplicateName verifies the invariant is
+// enforced at the point of entry, so RemoveSite's ambiguity is unreachable in
+// the first place.
+func TestCoordinator_AddSiteUnique_RejectsDuplicateName(t *testing.T) {
+	t.Parallel()
+
+	first, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(first)
+
+	dup, dupClient := makeMount("primary", types.SiteRoleBackup, nil) // different role, same name
+	err := c.AddSiteUnique(dup)
+	if err == nil {
+		t.Fatal("AddSiteUnique accepted a duplicate name")
+	}
+	if !errors.Is(err, ErrDuplicateSite) {
+		t.Errorf("expected ErrDuplicateSite, got %v", err)
+	}
+	if got := len(c.Sites()); got != 1 {
+		t.Errorf("site count is %d after a rejected add, want 1", got)
+	}
+	// The rejected site belongs to the caller; AddSiteUnique must not close it.
+	if got := dupClient.closeCount(); got != 0 {
+		t.Errorf("rejected site was closed %d times, want 0 — ownership stays with the caller", got)
+	}
+
+	// A distinct name still works, and lands at lowest priority.
+	fresh, _ := makeMount("backup", types.SiteRoleBackup, nil)
+	if err := c.AddSiteUnique(fresh); err != nil {
+		t.Fatalf("AddSiteUnique with a fresh name: %v", err)
+	}
+	if got := siteNames(c.Sites()); len(got) != 2 || got[1] != "backup" {
+		t.Errorf("sites = %v, want [primary backup]", got)
+	}
+}
+
+// TestCoordinator_AddSiteUnique_Concurrent verifies the check and the append are
+// one atomic step: N racing adds of the same name must yield exactly one site.
+func TestCoordinator_AddSiteUnique_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	const racers = 16
+	var wg sync.WaitGroup
+	accepted := make(chan struct{}, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s, _ := makeMount("primary", types.SiteRolePrimary, nil)
+			if err := c.AddSiteUnique(s); err == nil {
+				accepted <- struct{}{}
+			}
+		}()
+	}
+	wg.Wait()
+	close(accepted)
+
+	if got := len(accepted); got != 1 {
+		t.Errorf("%d concurrent adds of the same name were accepted, want 1", got)
+	}
+	if got := len(c.Sites()); got != 1 {
+		t.Errorf("coordinator holds %d sites after racing adds, want 1", got)
 	}
 }
 

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -3,11 +3,14 @@ package coordinator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	objectfserrors "github.com/scttfrdmn/objectfs/pkg/errors"
 	objectfstypes "github.com/scttfrdmn/objectfs/pkg/types"
+	objectfssdk "github.com/scttfrdmn/objectfs/sdks/go/objectfs"
 
 	"github.com/scttfrdmn/globalfs/internal/cache"
 	"github.com/scttfrdmn/globalfs/internal/circuitbreaker"
@@ -46,6 +49,15 @@ func newMemClient(objs map[string][]byte) *memClient {
 	return &memClient{objects: objs}
 }
 
+// notFound returns the error a real objectfs client returns for an absent key.
+// It is code-matched by errors.Is against objectfssdk.ErrNotFound, including
+// through wrapping, which is what the coordinator's classification relies on.
+func notFound(key string) error {
+	return objectfserrors.NewError(objectfserrors.ErrCodeObjectNotFound, "object does not exist").
+		WithComponent("memclient").
+		WithContext("key", key)
+}
+
 func (m *memClient) Get(_ context.Context, key string, _, _ int64) ([]byte, error) {
 	// getFn takes precedence over the static error/objects behaviour.
 	if m.getFn != nil {
@@ -58,7 +70,7 @@ func (m *memClient) Get(_ context.Context, key string, _, _ int64) ([]byte, erro
 	defer m.mu.Unlock()
 	data, ok := m.objects[key]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, notFound(key)
 	}
 	cp := make([]byte, len(data))
 	copy(cp, data)
@@ -116,7 +128,7 @@ func (m *memClient) Head(_ context.Context, key string) (*objectfstypes.ObjectIn
 	defer m.mu.Unlock()
 	data, ok := m.objects[key]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, notFound(key)
 	}
 	return &objectfstypes.ObjectInfo{
 		Key:          key,
@@ -1463,6 +1475,227 @@ func TestFilterByCircuitBreaker_NilBreakerPassesThrough(t *testing.T) {
 	if len(got) != 1 {
 		t.Errorf("nil cb: expected 1 site, got %d", len(got))
 	}
+}
+
+// ─── Not-found classification (#77) ───────────────────────────────────────────
+
+// TestCoordinator_Get_MissingKeyDoesNotTripBreaker verifies that reads of an
+// absent key leave the circuit closed.  Before #77 every non-nil error recorded
+// a failure, so five cache misses at the default threshold ejected a healthy
+// site from routing for the whole cooldown.
+func TestCoordinator_Get_MissingKeyDoesNotTripBreaker(t *testing.T) {
+	t.Parallel()
+
+	// The site is entirely healthy — it just does not hold this key.
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"present.bam": []byte("data"),
+	})
+
+	cb := circuitbreaker.New(5, time.Hour) // the shipped default threshold
+	c := New(primary)
+	c.SetCircuitBreaker(cb)
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		_, err := c.Get(ctx, "absent.bam")
+		if err == nil {
+			t.Fatal("Get of an absent key should return an error")
+		}
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("Get of an absent key: error should wrap ErrNotFound, got %v", err)
+		}
+	}
+
+	if got := cb.State("primary"); got != circuitbreaker.StateClosed {
+		t.Errorf("circuit after 10 misses on a healthy site: got %v, want closed", got)
+	}
+
+	// The site must still be readable — the point of the bug was that it wasn't.
+	data, err := c.Get(ctx, "present.bam")
+	if err != nil {
+		t.Fatalf("Get of a present key after 10 misses: %v", err)
+	}
+	if string(data) != "data" {
+		t.Errorf("Get: got %q, want data", data)
+	}
+}
+
+// TestCoordinator_Head_MissingKeyDoesNotTripBreaker is the Head half of #77.
+func TestCoordinator_Head_MissingKeyDoesNotTripBreaker(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+
+	cb := circuitbreaker.New(5, time.Hour)
+	c := New(primary)
+	c.SetCircuitBreaker(cb)
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		if _, err := c.Head(ctx, "absent.bam"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("Head of an absent key: error should wrap ErrNotFound, got %v", err)
+		}
+	}
+
+	if got := cb.State("primary"); got != circuitbreaker.StateClosed {
+		t.Errorf("circuit after 10 Head misses: got %v, want closed", got)
+	}
+}
+
+// TestCoordinator_Get_RealFailureStillTripsBreaker guards the other direction:
+// the classification must not have made the breaker inert.
+func TestCoordinator_Get_RealFailureStillTripsBreaker(t *testing.T) {
+	t.Parallel()
+
+	// A bare error carrying no objectfs code — the unclassifiable case, which
+	// counts as a failure by design.
+	client := &memClient{getErr: errors.New("S3 unreachable"), objects: map[string][]byte{}}
+	primary := site.New("primary", types.SiteRolePrimary, client)
+
+	cb := circuitbreaker.New(3, time.Hour)
+	c := New(primary)
+	c.SetCircuitBreaker(cb)
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		_, _ = c.Get(ctx, "key")
+	}
+
+	if got := cb.State("primary"); got != circuitbreaker.StateOpen {
+		t.Errorf("circuit after 3 genuine failures: got %v, want open", got)
+	}
+}
+
+// TestCoordinator_Get_NotFoundIsDistinguishableFromOutage verifies that the two
+// conditions produce different errors, which is what lets the API layer return
+// 404 for one and 502 for the other.
+func TestCoordinator_Get_NotFoundIsDistinguishableFromOutage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	absent, _ := makeMount("absent", types.SiteRolePrimary, nil)
+	_, err := New(absent).Get(ctx, "k")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("absent key: expected ErrNotFound, got %v", err)
+	}
+	// ErrNotFound wraps the objectfs sentinel, so callers may test either.
+	if !errors.Is(err, objectfssdk.ErrNotFound) {
+		t.Errorf("absent key: expected error to wrap objectfssdk.ErrNotFound, got %v", err)
+	}
+
+	down := site.New("down", types.SiteRolePrimary,
+		&memClient{getErr: errors.New("connection refused"), objects: map[string][]byte{}})
+	_, err = New(down).Get(ctx, "k")
+	if err == nil {
+		t.Fatal("unreachable site: expected an error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Errorf("unreachable site: must NOT report ErrNotFound, got %v", err)
+	}
+}
+
+// TestCoordinator_Get_MixedNotFoundAndFailureIsNotNotFound verifies that one
+// site failing to answer is enough to make the whole read an outage rather than
+// an absence: the object may well exist on the site that could not be reached.
+func TestCoordinator_Get_MixedNotFoundAndFailureIsNotNotFound(t *testing.T) {
+	t.Parallel()
+
+	absent, _ := makeMount("absent", types.SiteRolePrimary, nil)
+	down := site.New("down", types.SiteRoleBackup,
+		&memClient{getErr: errors.New("connection refused"), objects: map[string][]byte{}})
+
+	_, err := New(absent, down).Get(context.Background(), "k")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Errorf("one site unreachable: must not claim not-found, got %v", err)
+	}
+}
+
+// TestCoordinator_Get_NotFoundIsNotRetried verifies that a missing key costs one
+// round trip, not MaxAttempts.  Retrying an absent key is pointless: the site
+// answered, and it will answer the same way three times.
+func TestCoordinator_Get_NotFoundIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	client := &memClient{objects: map[string][]byte{}}
+	primary := site.New("primary", types.SiteRolePrimary, client)
+
+	calls := 0
+	client.getFn = func(key string) ([]byte, error) {
+		calls++
+		return nil, notFound(key)
+	}
+
+	c := New(primary)
+	c.SetRetryConfig(&retry.Config{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		Multiplier:   1.0,
+	})
+
+	_, err := c.Get(context.Background(), "absent")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("absent key produced %d site calls, want 1 (not-found is not transient)", calls)
+	}
+}
+
+// TestIsSiteFailure_Classification pins the classification table directly.
+func TestIsSiteFailure_Classification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"object not found", notFound("k"), false},
+		{"wrapped not found", fmt.Errorf("get from %q: %w", "primary", notFound("k")), false},
+		{"context canceled", context.Canceled, false},
+		{"wrapped context canceled", fmt.Errorf("site attempt: %w", context.Canceled), false},
+		{"access denied", objectfserrors.NewError(objectfserrors.ErrCodeAccessDenied, "denied"), true},
+		{"connection failed", objectfserrors.NewError(objectfserrors.ErrCodeConnectionFailed, "refused"), true},
+		{"uncoded error counts as a failure", errors.New("something went wrong"), true},
+	}
+	for _, tc := range tests {
+		if got := isSiteFailure(tc.err); got != tc.want {
+			t.Errorf("isSiteFailure(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRecordSiteResult_NotFoundRecordsSuccess verifies that a non-failure error
+// records a success rather than merely skipping the failure.  The site was
+// reached and it answered, which is what the breaker measures — and it means a
+// site recovering via cache misses closes its circuit.
+func TestRecordSiteResult_NotFoundRecordsSuccess(t *testing.T) {
+	t.Parallel()
+
+	cb := circuitbreaker.New(3, time.Hour)
+	cb.RecordFailure("s")
+	cb.RecordFailure("s")
+
+	recordSiteResult(cb, "s", notFound("k"))
+
+	// The failure counter must have been reset: one more genuine failure should
+	// not be enough to open a threshold-3 circuit.
+	recordSiteResult(cb, "s", errors.New("boom"))
+	if got := cb.State("s"); got != circuitbreaker.StateClosed {
+		t.Errorf("state: got %v, want closed (not-found should have reset the counter)", got)
+	}
+}
+
+// TestRecordSiteResult_NilBreakerIsNoop guards the nil-breaker path.
+func TestRecordSiteResult_NilBreakerIsNoop(t *testing.T) {
+	t.Parallel()
+	recordSiteResult(nil, "s", errors.New("boom")) // must not panic
+	recordSiteResult(nil, "s", nil)
 }
 
 // ─── Retry tests ──────────────────────────────────────────────────────────────

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -17,6 +17,7 @@ type Metrics struct {
 	sitesCurrent          prometheus.Gauge
 	replicationTotal      *prometheus.CounterVec
 	replicationQueueDepth prometheus.Gauge
+	replicationDropped    prometheus.Counter
 	cacheHits             prometheus.Counter
 	cacheMisses           prometheus.Counter
 	cacheEvictions        prometheus.Counter
@@ -58,6 +59,11 @@ func New(reg prometheus.Registerer) *Metrics {
 			Name: "globalfs_replication_queue_depth",
 			Help: "Current number of jobs waiting in the replication queue.",
 		}),
+		replicationDropped: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "globalfs_replication_dropped_total",
+			Help: "Total number of replication jobs rejected because the queue was full. " +
+				"Non-zero means writes were not replicated; alert on any increase.",
+		}),
 		cacheHits: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "globalfs_cache_hits_total",
 			Help: "Total number of cache hits.",
@@ -81,6 +87,7 @@ func New(reg prometheus.Registerer) *Metrics {
 		m.sitesCurrent,
 		m.replicationTotal,
 		m.replicationQueueDepth,
+		m.replicationDropped,
 		m.cacheHits,
 		m.cacheMisses,
 		m.cacheEvictions,
@@ -123,6 +130,20 @@ func (m *Metrics) SetReplicationQueueDepth(n int) {
 		return
 	}
 	m.replicationQueueDepth.Set(float64(n))
+}
+
+// RecordReplicationDropped increments the count of replication jobs that were
+// rejected because the queue was full.
+//
+// This is monotonic and never reset, unlike the queue-depth gauge: a drop is a
+// write that was not replicated, and the operator needs to see that it happened
+// even if the queue has since emptied.  Any non-zero value is a durability
+// event (#79).
+func (m *Metrics) RecordReplicationDropped() {
+	if m == nil {
+		return
+	}
+	m.replicationDropped.Inc()
 }
 
 // RecordCacheHit increments the cache hit counter.


### PR DESCRIPTION
Four coordinator-layer bugs from the v0.2.2 milestone. One commit each, in the order they were fixed; all four touch only `internal/coordinator/*` and (for #79's counter) `internal/metrics/metrics.go`.

## #77 — a missing object counted as a site failure (`c858890`)

`Get`, `Head`, `Put` and `Delete` all fed every non-nil per-site error straight into `cb.RecordFailure`. The default breaker threshold is 5, so **five lookups of absent keys ejected a completely healthy site from read routing for the whole cooldown** — a site that was up, reachable, authenticating and answering correctly. Any workload that probes for keys before writing them did this to itself.

The fix is one classification helper rather than four patched call sites:

```go
func isSiteFailure(err error) bool
func recordSiteResult(cb *circuitbreaker.Breaker, name string, err error)
```

`isSiteFailure` delegates to objectfs's own `objectfserrors.IsServiceFailure`, the same function objectfs's health tracker and circuit breaker consult, so GlobalFS cannot drift from the classification made one layer down. It matches on the error *code*, so a backend error wrapped several times over still resolves. Notes on the edges:

- A non-failure error records a **success**: the site was reached and it answered, which is what the breaker measures. This mirrors objectfs's `defaultIsSuccessful`.
- An error carrying no objectfs code counts as a failure. Deliberate, and matches objectfs: misclassifying something unknown gives a breaker that opens too eagerly and recovers on its cooldown, rather than one that never notices an outage.
- `context.Canceled` is named explicitly. objectfs classifies it as a non-failure by code, but GlobalFS produces the bare context error itself (`retry.Do` returns `ctx.Err()` directly), so it arrives with no code attached.

Two consequences beyond the breaker:

- New `ErrNotFound` sentinel, wrapping `objectfssdk.ErrNotFound`. `Get`/`Head` return it when *every* site answered "no such key", which is a different fact from "every site errored" and the thing an HTTP layer needs in order to say 404 instead of 502.
- Not-found is now terminal in `doWithRetry`. `retry.Do` has no early-exit hook, so the callback stashes the terminal error and returns nil to stop the loop. Previously a missing key was retried with full backoff on every site.

Reproduced before fixing with a scratch test: `circuit state after 5 misses on a healthy site: open`.

## #78 — `Stop()` tore down the event consumer while the producer was still working (`5792f5b`)

`Stop` called `storeCancel()` (killing `drainWorkerEvents`) and only then `c.worker.Stop()`. The worker finishes its in-flight job and emits a terminal event into a channel nobody is reading any more, so the completion was lost: the job stayed in the metadata store as pending forever and the replication metrics never recorded it.

**Ordering alone is not sufficient**, and the test proves it — with the corrected order but no final flush, `TestCoordinator_Stop_DrainFlushesBufferedEvents` still fails with `store has 1 pending job(s); a buffered terminal event went unread`. `cmd/coordinator` cancels the root context and *then* calls `Close`, so the drain can already have exited before `Stop` is entered; the same is true after a lost leader lease, which cancels `leaderCtx` with no `Stop` involved. So the shutdown is now three explicit steps:

1. `c.worker.Stop()` — producer first. It waits for the in-flight job, and the events channel is buffered to the queue depth, so `emit` cannot block even with no reader scheduled.
2. Cancel the lease and store contexts, then `storeWg.Wait()` — consumer second.
3. `c.flushWorkerEvents(store)` on the calling goroutine. `storeWg.Wait()` guarantees no concurrent reader; the flush is non-blocking (`default: return`) so it costs one channel read when the buffer is empty.

`drainWorkerEvents` also flushes on its own `ctx.Done()`, and the shared handling moved into `handleWorkerEvent` so both paths settle a job identically.

Kept clear of the other `Stop` bugs on purpose. #82/#83/#84 are v0.2.3 and none of them get harder from here. One thing worth flagging for #83: `leaderCancel()` used to run first, and since `leaderCtx` is the worker's context that incidentally gave the in-flight transfer a cancellation path. It no longer does — aborting the transfer is the opposite of letting it settle. That path never existed in the no-lease-manager case, which is every shipped deployment, and bounding a transfer against an unresponsive site wants a real timeout, which is #83's job. Noted in a comment at the site.

## #79 — a full replication queue made `Put` return nil (`3dd76c3`)

`Put` enqueued to each non-primary destination with a non-blocking `worker.Enqueue`, logged failures at **warn**, and returned nil. The queue is bounded and much smaller than it looks — the daemon passes `Performance.MaxConcurrentTransfers` (default 8) as the queue depth — and the worker is serial, so a burst fills it in milliseconds. **At the shipped defaults a 40-write burst against a slow destination queued 9 and silently discarded 31, all 40 returning nil.** With no metadata store configured (every shipped deployment today) nothing ever recovers the job.

### What `Put` should do, and why

Neither obvious option is defensible. Returning nil tells the caller a write was replicated when it was not. Returning a plain error fails a write that is already durably committed to the primary and readable immediately, which callers will retry forever or escalate as data loss. So, three parts:

1. **Bounded backpressure.** `enqueueWithBackpressure` polls `Enqueue` every 5 ms for up to a 2 s budget (`SetEnqueueBackpressure` overrides; negative = no wait). A job leaves the queue as soon as the serial worker picks it up, so the wait is normally one transfer long and a burst becomes a queue rather than data loss. The budget is finite **on purpose**: unbounded blocking would make the async path synchronous under load and let one wedged destination stall every writer. This is the part that fixes the common case — a 20-write burst against a depth-1 queue now delivers all 20.
2. **A distinct partial-success sentinel** for the case that survives the wait. `ErrReplicationNotQueued`, naming the destinations that got no job and wrapping the underlying cause, so a caller can tell "we gave up waiting" from "you cancelled". The bytes are on every primary; retrying the identical `Put` is safe and is the intended response, since the primary write is idempotent and the coordinator-level dedup skips destinations that already hold the content hash. A cancelled context also stops the loop from polling each remaining destination for a full budget.
3. **A monotonic `globalfs_replication_dropped_total` counter.** The existing queue-depth gauge cannot serve as the signal: it only moves when a job settles and it reads zero again once the backlog clears, so a drop leaves no trace after the fact. Help text says so, and says to alert on any increase. (This is the one counter #79 asked for; the broader metrics work in #103 is untouched.)

An HTTP layer should map `ErrReplicationNotQueued` to **202 Accepted**, not 5xx — the object exists and is retrievable. `cmd/coordinator`'s blanket 502 for `Put` errors is wrong for this case; that file belongs to another agent, so it is documented at `Put` and left alone.

## #80 — `RemoveSite` removed every site sharing a name and closed only one (`a0236db`)

The match loop ran to completion with no `break`, assigning each match over the last, and filtered *all* of them out — then closed only the survivor of the assignments. With two sites named `primary`, one `RemoveSite("primary")` returned true, left **zero** sites, and leaked the un-closed `SiteMount`'s S3 connection pool, reintroducing by another route the leak #62 fixed.

`RemoveSite` now removes exactly one site per call — the highest-priority match, spliced out by index with a `break` — and that is the site it closes. A second call takes the next duplicate, so the state stays reachable without a restart. The close still happens **after** `c.mu.Unlock`, which was already deliberate and is now commented as such so it survives the next edit; #95 is open precisely because `Close` does not do this.

Duplicates should not be reachable at all, so the invariant is enforced at entry too. New `AddSiteUnique` rejects an already-registered name with an error wrapping `ErrDuplicateSite`, doing the check and the append under a single lock hold so two racing callers cannot both win the same name. A rejected site is not closed — the caller built it and decides its fate. `AddSite` stays for callers with a name they already trust (config loading validates uniqueness at parse time), with a doc comment explaining when the choice matters.

**Boundary:** the HTTP half — mapping `ErrDuplicateSite` to 409 in `addSiteHandler`, which performs no duplicate check today — is in `cmd/coordinator/api.go`, owned by another agent. `AddSiteUnique` plus the sentinel is exactly what that handler needs. Likewise the 404 mapping for `ErrNotFound` from #77 is tracked separately as #110.

## Verification

Every new test was confirmed to fail against the prior behaviour before being kept. `git stash` was not good enough for this: reverting the whole file produced *compile* errors (`undefined: ErrNotFound`, …), which demonstrates nothing about whether a test catches a bug. Instead each revert was behaviour-only, patched in place with the new symbols left declared, so the failures are real assertions:

- #77 — 6 tests fail, e.g. a healthy site's circuit open after 5 misses.
- #78 — both store tests fail: `store has 1 pending job(s); a buffered terminal event went unread`.
- #79 — all 6 fail: `all 12 Puts reported success with a permanently full queue of depth 2`; `globalfs_replication_dropped_total is 0`; `backup holds 12 of 20 objects — a burst was silently dropped`.
- #80 — 3 fail: `after one RemoveSite the coordinator holds 1 sites, want 2`; `AddSiteUnique accepted a duplicate name`; `16 concurrent adds of the same name were accepted, want 1`.

The tests also pin the properties that must not regress: the primary write always lands, the partial-success sentinel stays distinguishable from a genuine write failure, the backpressure wait honours context cancellation instead of hanging, and site removal closes exactly what it removed (Close counter on the test client — one close for the removed site, none for the retained duplicate, none for a miss, no double close).

Required commands, on the final tree:

```
$ go build ./... && go vet ./... && gofmt -l .
(no output)

$ go test -race -timeout=5m ./...
ok  	github.com/scttfrdmn/globalfs/cmd/coordinator	3.499s
ok  	github.com/scttfrdmn/globalfs/cmd/globalfs	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/cache	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/circuitbreaker	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/coordinator	2.420s
ok  	github.com/scttfrdmn/globalfs/internal/lease	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/metadata	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/metrics	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/policy	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/replication	(cached)
ok  	github.com/scttfrdmn/globalfs/internal/retry	(cached)
ok  	github.com/scttfrdmn/globalfs/pkg/client	(cached)
ok  	github.com/scttfrdmn/globalfs/pkg/config	(cached)
ok  	github.com/scttfrdmn/globalfs/pkg/namespace	(cached)
ok  	github.com/scttfrdmn/globalfs/pkg/site	(cached)
?   	github.com/scttfrdmn/globalfs/pkg/types	[no test files]
```

The shutdown and queue tests were additionally run at `-count=3` (and #78's at `-cpu=1,2`) since both are timing-sensitive.

`CHANGELOG.md` deliberately untouched — being written after merge.
