### PR TITLE
fix: v0.2.3 replication events channel (#93)

### DIFF
--- a/internal/replication/worker.go
+++ b/internal/replication/worker.go
@@ -37,9 +37,31 @@
 //
 // For each job the worker emits an EventStarted before the first attempt and
 // either EventCompleted or EventFailed when the job settles.  Drain the
-// channel returned by Events to observe progress.  The channel is buffered to
-// the same depth as the work queue; if it fills, events are dropped (logged)
-// rather than blocking the worker.
+// channel returned by Events to observe progress.
+//
+// The two kinds are not equally droppable, and the worker does not treat them
+// as if they were (#93).  A terminal event is the only signal that the job
+// finished: the coordinator deletes the durable job record and writes the
+// dedup content hash when it receives one, so losing it leaves a phantom job
+// that is re-enqueued on the next restart and a successful transfer that the
+// content-hash index does not know about.  An EventStarted, by contrast, has no
+// consumer that acts on it.  So:
+//
+//   - The buffer is sized from the number of emit sites per job, not from the
+//     queue depth (see eventBufferSize).  Sizing alone is not a guarantee —
+//     a stalled consumer overruns any fixed buffer — it just makes the
+//     guarantee below rarely need to do anything.
+//   - EventStarted is admitted only while the buffer is below its reserve (see
+//     terminalReserveSlots), so it can never be the reason a terminal event has
+//     nowhere to go.
+//   - A terminal event waits for room, bounded by terminalEmitBudget, instead
+//     of being discarded on the first full buffer.  The wait is deliberately
+//     not cancellable by Stop or by the job's context: Stop exists to let the
+//     in-flight job settle, and settling is precisely what emitting the
+//     terminal event means.
+//   - If the budget elapses the event is lost, and that is reported at Error
+//     with the consequence named, plus a monotonic counter
+//     (DroppedTerminalEvents) so the loss is observable after the log scrolls.
 //
 // # Panic containment
 //
@@ -60,6 +82,7 @@ import (
 	"math"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/scttfrdmn/globalfs/pkg/site"
@@ -109,6 +132,32 @@ const (
 	MaxRetries = 3
 
 	defaultBaseBackoff = 100 * time.Millisecond
+
+	// eventsPerJob is how many events processJob emits for one job: an
+	// EventStarted, then exactly one of EventCompleted/EventFailed.  It is a
+	// property of the emit sites in processJob, not a tuning knob — if a third
+	// emit site is added, this is the number that has to change with it.
+	eventsPerJob = 2
+
+	// eventBufferSlack is extra room beyond one full queue's worth of events.
+	// The queue is not the only source of jobs the consumer has to keep up with:
+	// a job leaves the queue the moment the serial worker picks it up, so
+	// callers can refill the queue while earlier jobs' events are still
+	// unconsumed.  The slack absorbs that overlap so that the bounded wait in
+	// emitTerminal stays a backstop for a genuinely stalled consumer rather
+	// than something ordinary bursts reach.
+	eventBufferSlack = 64
+
+	// terminalEmitBudget bounds how long a terminal event waits for buffer room
+	// before it is abandoned.  It is finite because the alternative — an
+	// unbounded blocking send — makes any wedged consumer wedge the worker
+	// goroutine, and Stop waits on that goroutine, trading a lost event for a
+	// shutdown that never completes.  Ten seconds is orders of magnitude beyond
+	// what a consumer that is running at all needs to service one event (the
+	// coordinator's handler does two 5 s-bounded store calls at worst), and
+	// Stop only ever waits on one job, so it bounds shutdown's exposure at one
+	// budget.
+	terminalEmitBudget = 10 * time.Second
 )
 
 // workerState is the Worker's position in its one-directional lifecycle.
@@ -137,6 +186,19 @@ func (s workerState) String() string {
 	}
 }
 
+// eventBufferSize returns the capacity for the events channel given a job queue
+// depth.
+//
+// It is deliberately not depth.  Every job emits eventsPerJob events into this
+// channel while occupying one queue slot, so a channel of depth held only
+// depth/eventsPerJob jobs' worth of terminal events — at the shipped default
+// depth of 8, a burst of five writes was enough to start discarding completions
+// (#93).  Sizing it at depth*eventsPerJob restores the intended relationship,
+// and the slack covers jobs that have already left the queue.
+func eventBufferSize(depth int) int {
+	return depth*eventsPerJob + eventBufferSlack
+}
+
 // Worker processes ReplicationJobs from a bounded FIFO queue.
 //
 // Each job is attempted up to MaxRetries times with exponential backoff
@@ -158,6 +220,15 @@ type Worker struct {
 	// baseBackoff controls the initial retry delay.  Defaults to
 	// defaultBaseBackoff; may be overridden in tests.
 	baseBackoff time.Duration
+
+	// terminalBudget bounds the wait for buffer room when emitting a terminal
+	// event.  Zero means terminalEmitBudget; may be shortened in tests.
+	terminalBudget time.Duration
+
+	// droppedTerminal counts terminal events that were abandoned because the
+	// consumer did not free buffer room within the budget.  Each one is a job
+	// the coordinator will never learn settled.
+	droppedTerminal atomic.Uint64
 }
 
 // NewWorker creates a Worker with the given queue depth.
@@ -168,7 +239,7 @@ func NewWorker(depth int) *Worker {
 	}
 	return &Worker{
 		queue:       make(chan ReplicationJob, depth),
-		events:      make(chan ReplicationEvent, depth),
+		events:      make(chan ReplicationEvent, eventBufferSize(depth)),
 		done:        make(chan struct{}),
 		baseBackoff: defaultBaseBackoff,
 	}
@@ -176,10 +247,28 @@ func NewWorker(depth int) *Worker {
 
 // Events returns the read-only channel of ReplicationEvents.
 //
-// Events are buffered to the same depth as the work queue.  Drain this
-// channel or use a select with context.Done to avoid event drops.
+// The buffer holds eventBufferSize(depth) events, which is more than the queue
+// depth because each job emits several (see the package Events section).  Drain
+// this channel or use a select with context.Done: a consumer that stops reading
+// for longer than terminalEmitBudget still loses events, and losing a terminal
+// event corrupts the coordinator's job bookkeeping.
 func (w *Worker) Events() <-chan ReplicationEvent {
 	return w.events
+}
+
+// DroppedTerminalEvents returns the monotonic count of EventCompleted and
+// EventFailed events the worker could not deliver because the events buffer
+// stayed full for terminalEmitBudget.
+//
+// A non-zero value means the coordinator's view of replication is wrong: for
+// each drop there is a job record that will never be deleted (and is replayed
+// on the next restart) and, for a completion, a content hash that was never
+// written, so the same bytes will be transferred again.  It is exposed rather
+// than only logged so the loss remains visible after the log line scrolls
+// away; wiring it to a Prometheus counter belongs to the coordinator, which
+// owns the metrics registry.
+func (w *Worker) DroppedTerminalEvents() uint64 {
+	return w.droppedTerminal.Load()
 }
 
 // QueueDepth returns the number of jobs currently waiting in the queue.
@@ -385,12 +474,117 @@ func (w *Worker) processJob(ctx context.Context, job ReplicationJob) {
 	})
 }
 
+// isTerminal reports whether ev settles a job, i.e. whether the coordinator
+// acts on it.  Only terminal events delete the durable job record and record
+// the dedup content hash.
+func isTerminal(t EventType) bool {
+	return t == EventCompleted || t == EventFailed
+}
+
+// emit delivers ev to the events channel.
+//
+// The two kinds of event get different guarantees, because the cost of losing
+// them differs by more than a log line (#93).  Terminal events go through
+// emitTerminal, which waits for room; EventStarted is admitted non-blocking and
+// only while the buffer is below the reserve, so a flood of started events
+// cannot be the reason a completion has nowhere to go.
 func (w *Worker) emit(ev ReplicationEvent) {
+	if isTerminal(ev.Type) {
+		w.emitTerminal(ev)
+		return
+	}
+
+	// Non-terminal: droppable by design.  Its only consumer is metrics, and the
+	// coordinator's handleWorkerEvent ignores it outright.
+	if len(w.events)+terminalReserveSlots >= cap(w.events) {
+		slog.Debug("replication: events buffer near capacity; dropping non-terminal event",
+			"type", ev.Type, "key", ev.Job.Key,
+			"buffered", len(w.events), "capacity", cap(w.events))
+		return
+	}
 	select {
 	case w.events <- ev:
 	default:
-		slog.Warn("replication: events channel full; dropping event", "type", ev.Type, "key", ev.Job.Key)
+		// Lost the race for the last unreserved slot.  Same outcome as above.
+		slog.Debug("replication: events buffer full; dropping non-terminal event",
+			"type", ev.Type, "key", ev.Job.Key)
 	}
+}
+
+// terminalReserveSlots is the number of buffer slots withheld from
+// EventStarted so that a terminal event always has somewhere to go.
+//
+// One is sufficient because the worker is serial: Start guards the run
+// goroutine with sync.Once and run calls runJob sequentially, so at most one
+// job is between its EventStarted and its terminal event at any instant.  If
+// the worker ever grows a concurrent pool, this has to become that pool's size
+// — the invariant is one reserved slot per in-flight job, not one overall.
+const terminalReserveSlots = 1
+
+// emitTerminal delivers a job's settling event, waiting up to the terminal
+// budget for buffer room rather than discarding it on a full buffer.
+//
+// The wait deliberately does not select on w.done or the job's context.  Both
+// mean "stop working", and this event is the record that the work already
+// finished; abandoning it on cancellation would reintroduce #78's phantom job
+// in a narrower window.  Stop waits for the in-flight job, and there is only
+// ever one, so the worst case Stop inherits from this is a single budget.
+//
+// The budget is finite because an unbounded send would let a consumer that has
+// stopped reading wedge the worker goroutine permanently, and Stop waits on
+// that goroutine — trading a lost event for a shutdown that never completes.
+// Under a stalled consumer the wait instead degrades into backpressure: the
+// worker slows to one job per budget, the queue fills, and Put's enqueue
+// backpressure (#79) reports the condition to writers, which is a far better
+// failure mode than silently losing bookkeeping.
+func (w *Worker) emitTerminal(ev ReplicationEvent) {
+	// Fast path: room right now, which is the overwhelmingly common case given
+	// eventBufferSize and the reserve above.
+	select {
+	case w.events <- ev:
+		return
+	default:
+	}
+
+	budget := w.terminalBudget
+	if budget <= 0 {
+		budget = terminalEmitBudget
+	}
+
+	slog.Warn("replication: events buffer full; waiting to deliver terminal event",
+		"type", ev.Type, "key", ev.Job.Key,
+		"dest", ev.Job.DestSite.Name(),
+		"capacity", cap(w.events), "budget", budget)
+
+	deadline := time.NewTimer(budget)
+	defer deadline.Stop()
+
+	// A select with a send case blocks until the send can proceed, so no polling
+	// is needed: this parks the worker until either room appears or the budget
+	// expires.
+	select {
+	case w.events <- ev:
+		return
+	case <-deadline.C:
+	}
+
+	// The timer and the send can both become ready in the same window, and
+	// select picks at random between them, so try once more before giving up.
+	select {
+	case w.events <- ev:
+		return
+	default:
+	}
+
+	w.droppedTerminal.Add(1)
+	slog.Error("replication: dropped terminal replication event; "+
+		"the job record will not be deleted and will be re-enqueued on restart, "+
+		"and its content hash was not recorded so the object will be transferred again",
+		"type", ev.Type, "key", ev.Job.Key,
+		"src", ev.Job.SourceSite.Name(), "dst", ev.Job.DestSite.Name(),
+		"attempt", ev.Attempt, "waited", budget,
+		"capacity", cap(w.events),
+		"dropped_total", w.droppedTerminal.Load())
 }
 
 // safeTransfer calls transfer and converts a panic into an ordinary error so

--- a/internal/replication/worker_test.go
+++ b/internal/replication/worker_test.go
@@ -948,3 +948,431 @@ func TestWorker_PanicInTransfer_FailsJobAndKeepsWorkerAlive(t *testing.T) {
 	}
 	t.Error("worker did not process a job after recovering from a panic")
 }
+
+// ─── #93: the events buffer and terminal-event droppability ────────────────────
+
+// fillEvents pushes n synthetic events straight into w.events, bypassing emit,
+// so a test can put the buffer into an exactly-known state.
+func fillEvents(t *testing.T, w *Worker, n int) {
+	t.Helper()
+	src, _ := makeMount("filler-src", types.SiteRolePrimary, nil)
+	dst, _ := makeMount("filler-dst", types.SiteRoleBackup, nil)
+	for i := 0; i < n; i++ {
+		select {
+		case w.events <- ReplicationEvent{
+			Job:  ReplicationJob{SourceSite: src, DestSite: dst, Key: "filler"},
+			Type: EventStarted,
+		}:
+		default:
+			t.Fatalf("fillEvents: buffer full after %d of %d (cap %d)", i, n, cap(w.events))
+		}
+	}
+}
+
+// drainTerminalEvents reads events until the channel has been quiet for the
+// given settle period, returning the terminal events seen keyed by object key.
+func drainTerminalEvents(w *Worker, settle time.Duration) map[string]int {
+	seen := make(map[string]int)
+	for {
+		select {
+		case ev := <-w.Events():
+			if ev.Type == EventCompleted || ev.Type == EventFailed {
+				seen[ev.Job.Key]++
+			}
+		case <-time.After(settle):
+			return seen
+		}
+	}
+}
+
+// TestWorker_BurstBeyondHalfDepth_NoTerminalEventLost is the #93 regression.
+//
+// The events channel used to be sized to the queue depth, but processJob emits
+// two events per job (EventStarted then a terminal one), so only depth/2 jobs'
+// worth of completions fitted and the rest were discarded with a warn log.  A
+// discarded completion is durable corruption, not a lost log line: the
+// coordinator deletes the persisted job and records the dedup content hash only
+// when it receives one.
+//
+// The consumer here reads nothing until every job has landed on the
+// destination, which is exactly the shipped daemon's worst case — the drain
+// goroutine descheduled while a burst of writes goes through.
+func TestWorker_BurstBeyondHalfDepth_NoTerminalEventLost(t *testing.T) {
+	t.Parallel()
+
+	const depth = 8 // the shipped default (Performance.MaxConcurrentTransfers)
+	keys := make([]string, depth)
+	srcObjs := make(map[string][]byte, depth)
+	for i := range keys {
+		keys[i] = string(rune('a'+i)) + ".bam"
+		srcObjs[keys[i]] = []byte(keys[i] + "-data")
+	}
+
+	src, _ := makeMount("src", types.SiteRolePrimary, srcObjs)
+	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(depth)
+	w.Start(ctx)
+	defer w.Stop()
+
+	for _, k := range keys {
+		if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: k}); err != nil {
+			t.Fatalf("Enqueue %q: unexpected error: %v", k, err)
+		}
+	}
+
+	// Deliberately read nothing until the transfers have all happened.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		all := true
+		for _, k := range keys {
+			if !dstClient.hasKey(k) {
+				all = false
+				break
+			}
+		}
+		if all {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	for _, k := range keys {
+		if !dstClient.hasKey(k) {
+			t.Fatalf("transfer of %q did not happen; test cannot judge event delivery", k)
+		}
+	}
+
+	seen := drainTerminalEvents(w, 500*time.Millisecond)
+	for _, k := range keys {
+		if seen[k] != 1 {
+			t.Errorf("terminal events for %q: got %d, want exactly 1", k, seen[k])
+		}
+	}
+	if len(seen) != depth {
+		t.Errorf("jobs with a terminal event: got %d, want %d (buffer cap %d)",
+			len(seen), depth, cap(w.events))
+	}
+	if got := w.DroppedTerminalEvents(); got != 0 {
+		t.Errorf("DroppedTerminalEvents: got %d, want 0", got)
+	}
+}
+
+// TestEventBufferSize_HoldsAWholeQueuesEvents pins the sizing relationship
+// itself, so raising the queue depth or adding a third emit site to processJob
+// cannot silently reintroduce the half-depth ceiling.
+func TestEventBufferSize_HoldsAWholeQueuesEvents(t *testing.T) {
+	t.Parallel()
+
+	for _, depth := range []int{1, 2, 8, 64, DefaultQueueDepth} {
+		if got, min := eventBufferSize(depth), depth*eventsPerJob; got < min {
+			t.Errorf("eventBufferSize(%d) = %d, want ≥ %d (%d events per job)",
+				depth, got, min, eventsPerJob)
+		}
+	}
+
+	w := NewWorker(8)
+	if got := cap(w.events); got < 8*eventsPerJob {
+		t.Errorf("NewWorker(8) events cap: got %d, want ≥ %d", got, 8*eventsPerJob)
+	}
+	if got := cap(w.queue); got != 8 {
+		t.Errorf("NewWorker(8) queue cap: got %d, want 8", got)
+	}
+}
+
+// TestWorker_EventStartedNeverConsumesTheTerminalReserve verifies the asymmetry
+// the fix rests on: with one slot left, a non-terminal event is refused and a
+// terminal event takes it.  Without the reserve a job's own EventStarted can
+// occupy the last slot and force its completion into the bounded wait.
+func TestWorker_EventStartedNeverConsumesTheTerminalReserve(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeMount("src", types.SiteRolePrimary, nil)
+	dst, _ := makeMount("dst", types.SiteRoleBackup, nil)
+	job := ReplicationJob{SourceSite: src, DestSite: dst, Key: "reserved"}
+
+	w := NewWorker(4)
+	fillEvents(t, w, cap(w.events)-terminalReserveSlots)
+	before := len(w.events)
+
+	w.emit(ReplicationEvent{Job: job, Type: EventStarted, Attempt: 1})
+	if got := len(w.events); got != before {
+		t.Errorf("EventStarted took a reserved slot: buffered %d → %d (cap %d)",
+			before, got, cap(w.events))
+	}
+
+	w.emit(ReplicationEvent{Job: job, Type: EventCompleted, Attempt: 1, ContentHash: "abc"})
+	if got := len(w.events); got != before+1 {
+		t.Errorf("EventCompleted did not use the reserved slot: buffered %d → %d", before, got)
+	}
+	if got := w.DroppedTerminalEvents(); got != 0 {
+		t.Errorf("DroppedTerminalEvents: got %d, want 0", got)
+	}
+}
+
+// TestWorker_TerminalEventWaitsForRoom verifies that a full buffer makes a
+// terminal event wait rather than vanish, and that it is delivered as soon as
+// the consumer catches up.
+func TestWorker_TerminalEventWaitsForRoom(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeMount("src", types.SiteRolePrimary, nil)
+	dst, _ := makeMount("dst", types.SiteRoleBackup, nil)
+
+	w := NewWorker(2)
+	w.terminalBudget = 5 * time.Second
+	fillEvents(t, w, cap(w.events))
+
+	// A consumer that is late, not absent.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		<-w.Events()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.emit(ReplicationEvent{
+			Job:         ReplicationJob{SourceSite: src, DestSite: dst, Key: "late"},
+			Type:        EventCompleted,
+			Attempt:     1,
+			ContentHash: "hash",
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("emit of a terminal event did not return within 5s")
+	}
+
+	if got := w.DroppedTerminalEvents(); got != 0 {
+		t.Fatalf("DroppedTerminalEvents: got %d, want 0 (event should have waited, not dropped)", got)
+	}
+
+	var found bool
+	for i := 0; i < cap(w.events); i++ {
+		ev, ok := drainEvent(t, w, time.Second)
+		if !ok {
+			break
+		}
+		if ev.Type == EventCompleted && ev.Job.Key == "late" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("the delayed EventCompleted was never delivered")
+	}
+}
+
+// TestWorker_TerminalEventDropIsCounted covers the case the bounded wait cannot
+// save: a consumer that never reads at all.  The event is lost — the budget is
+// finite on purpose, since an unbounded send would let that consumer wedge the
+// worker goroutine and therefore Stop — but it must be counted, not merely
+// warned about, so the resulting phantom job is attributable after the fact.
+func TestWorker_TerminalEventDropIsCounted(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeMount("src", types.SiteRolePrimary, nil)
+	dst, _ := makeMount("dst", types.SiteRoleBackup, nil)
+
+	w := NewWorker(2)
+	w.terminalBudget = 50 * time.Millisecond
+	fillEvents(t, w, cap(w.events))
+
+	start := time.Now()
+	w.emit(ReplicationEvent{
+		Job:     ReplicationJob{SourceSite: src, DestSite: dst, Key: "doomed"},
+		Type:    EventFailed,
+		Attempt: MaxRetries,
+		Err:     errors.New("nobody is listening"),
+	})
+	elapsed := time.Since(start)
+
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("emit gave up after %v, want ≥ the 50ms budget", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("emit took %v; the budget must bound it", elapsed)
+	}
+	if got := w.DroppedTerminalEvents(); got != 1 {
+		t.Errorf("DroppedTerminalEvents: got %d, want 1", got)
+	}
+
+	// Monotonic, and only terminal drops count.
+	w.emit(ReplicationEvent{
+		Job:  ReplicationJob{SourceSite: src, DestSite: dst, Key: "ignored"},
+		Type: EventStarted,
+	})
+	if got := w.DroppedTerminalEvents(); got != 1 {
+		t.Errorf("a dropped EventStarted changed the terminal counter: got %d, want 1", got)
+	}
+}
+
+// TestWorker_TerminalEmitIgnoresStopWhileWaiting pins a deliberate decision: the
+// wait for buffer room does not select on w.done.  Stop means "let the in-flight
+// job settle", and the terminal event *is* the record that it settled, so
+// abandoning it on Stop would reintroduce #78's phantom job in a narrower
+// window.  Stop's exposure is bounded at one budget because the worker is
+// serial.
+func TestWorker_TerminalEmitIgnoresStopWhileWaiting(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeMount("src", types.SiteRolePrimary, nil)
+	dst, _ := makeMount("dst", types.SiteRoleBackup, nil)
+
+	w := NewWorker(2)
+	w.terminalBudget = 5 * time.Second
+	fillEvents(t, w, cap(w.events))
+	close(w.done) // as if Stop had been called
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		<-w.Events()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.emit(ReplicationEvent{
+			Job:         ReplicationJob{SourceSite: src, DestSite: dst, Key: "settling"},
+			Type:        EventCompleted,
+			Attempt:     1,
+			ContentHash: "hash",
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("emit did not return within 5s")
+	}
+	if got := w.DroppedTerminalEvents(); got != 0 {
+		t.Errorf("terminal event abandoned because done was closed: dropped %d, want 0", got)
+	}
+
+	var found bool
+	for i := 0; i < cap(w.events); i++ {
+		ev, ok := drainEvent(t, w, time.Second)
+		if !ok {
+			break
+		}
+		if ev.Type == EventCompleted && ev.Job.Key == "settling" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("the terminal event of a job settling during Stop was never delivered")
+	}
+}
+
+// TestWorker_StalledConsumerBecomesBackpressure verifies the failure mode the
+// bounded wait produces under a genuinely stalled consumer: the worker stops
+// consuming its queue, rather than racing ahead transferring objects whose
+// bookkeeping is being discarded.
+//
+// That is the behavioural difference the fix buys beyond buffer sizing.  With
+// the old non-blocking emit the worker ran at full speed against a stalled
+// consumer, so the objects landed on the destination and the coordinator never
+// heard about any of them.  Now the backlog is visible where callers can act on
+// it: the queue fills, Enqueue reports it, and Put's backpressure path (#79)
+// surfaces it to writers.
+func TestWorker_StalledConsumerBecomesBackpressure(t *testing.T) {
+	t.Parallel()
+
+	const nJobs = 12
+	keys := make([]string, nJobs)
+	srcObjs := make(map[string][]byte, nJobs)
+	for i := range keys {
+		keys[i] = string(rune('a' + i))
+		srcObjs[keys[i]] = []byte("x")
+	}
+	src, _ := makeMount("src", types.SiteRolePrimary, srcObjs)
+	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A queue big enough for every job, so a full queue can only come from the
+	// worker having stopped draining it.
+	w := fastWorker(nJobs)
+	w.terminalBudget = time.Second
+	// Pre-fill the events buffer so the very first terminal event has to wait.
+	fillEvents(t, w, cap(w.events))
+	w.Start(ctx)
+	defer w.Stop()
+
+	// Nothing ever reads Events().
+	for _, k := range keys {
+		if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: k}); err != nil {
+			t.Fatalf("Enqueue %q: unexpected error: %v", k, err)
+		}
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	var transferred int
+	for _, k := range keys {
+		if dstClient.hasKey(k) {
+			transferred++
+		}
+	}
+	// The worker parks in emitTerminal on the first job it settles, so at most
+	// one transfer gets through.  Allowing two absorbs a slow scheduler.
+	if transferred > 2 {
+		t.Errorf("worker transferred %d of %d objects while its event consumer was stalled; "+
+			"it should have blocked on delivering the first terminal event", transferred, nJobs)
+	}
+	if got := w.QueueDepth(); got == 0 {
+		t.Error("queue drained to empty with a stalled consumer; the backlog is not visible to callers")
+	}
+	if got := w.DroppedTerminalEvents(); got != 0 {
+		t.Errorf("DroppedTerminalEvents: got %d, want 0 within the budget", got)
+	}
+}
+
+// TestWorker_StopCompletesWithNoEventConsumer is the safety property that makes
+// the bounded wait acceptable: waiting for buffer room must not let an absent
+// consumer wedge shutdown.  Stop waits on the worker goroutine, so if the wait
+// were an unbounded blocking send this would hang forever instead of finishing
+// with one counted drop.
+func TestWorker_StopCompletesWithNoEventConsumer(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeMount("src", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	dst, _ := makeMount("dst", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(1)
+	w.terminalBudget = 200 * time.Millisecond
+	fillEvents(t, w, cap(w.events)) // full buffer, and nothing will ever read it
+	w.Start(ctx)
+
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "k"}); err != nil {
+		t.Fatalf("Enqueue: unexpected error: %v", err)
+	}
+
+	stopped := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		w.Stop()
+		stopped <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-stopped:
+		// The queue holds one job, so Stop's exposure is one budget plus the
+		// transfer.  The generous ceiling is about not deadlocking, not timing.
+		if elapsed > 5*time.Second {
+			t.Errorf("Stop took %v with no event consumer; the budget must bound it", elapsed)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Stop did not return with no event consumer: a blocking terminal send wedged shutdown")
+	}
+}


### PR DESCRIPTION
Refs #93. Files touched: `internal/replication/worker.go`, `internal/replication/worker_test.go` only.

## The bug

`NewWorker` sized the events channel to the job queue depth, but `processJob`
emits **two** events per job — `EventStarted`, then exactly one of
`EventCompleted`/`EventFailed` — so the buffer held `depth/2` jobs' worth of
terminal events and `emit` discarded the rest on a full channel with a
`slog.Warn`.

Reproduced at the shipped default (the daemon passes
`Performance.MaxConcurrentTransfers`, 8): an 8-job burst with the consumer not
yet reading delivered terminal events for exactly **4** jobs.

The asymmetry is the whole issue. `handleWorkerEvent` is where the persisted
job record is deleted and the per-site dedup content hash is written, and it
ignores `EventStarted` outright. Every discarded completion leaves a phantom
job the next boot re-enqueues plus a successful transfer the content-hash index
does not know about — the same end state as #78, reached under ordinary load
with nothing shutting down.

## The fix

1. **`eventBufferSize(depth) = depth*eventsPerJob + eventBufferSlack`.** The
   `eventsPerJob` factor is the actual defect, now a named constant that a third
   emit site has to change. The 64 slack covers jobs that have already left the
   queue: a job vacates its slot the moment the serial worker picks it up, so
   callers refill the queue while earlier events are unconsumed, and `2*depth`
   alone does not bound that overlap.

2. **`EventStarted` no longer competes for the last slot.** It is admitted only
   while the buffer is below `terminalReserveSlots` (1 — the worker is serial, so
   at most one job sits between its started and its terminal event). A started
   event can never be the reason a completion has nowhere to go. Its drop log
   went to Debug: nothing consumes it, and warning about the harmless half of
   the pair is what trained the eye past the warning about the harmful half.

3. **Terminal events wait for room** instead of being discarded on the first full
   buffer, bounded by `terminalEmitBudget` (10s). The wait deliberately does not
   select on `w.done` or the job's context: both mean "stop working", and this
   event is the record that the work already *finished*, so abandoning it on
   cancellation reintroduces #78's phantom in a narrower window.

## Reasoning on droppability

**Why not just `2*depth`.** It moves the threshold rather than removing it. Any
fixed buffer is overrun by a consumer that stops reading, and the coordinator's
drain is a single goroutine a descheduled or store-blocked handler can stall for
an unbounded time. With sizing alone the loss stays possible *and stays silent* —
which is the part the issue asks not to survive.

**Why not an unbounded blocking send.** `Stop` waits on the worker goroutine, so
a wedged consumer would trade one lost event for a shutdown that never
completes. The budget is the compromise: long enough that a consumer which is
running at all cannot miss it (the coordinator's handler does two 5s-bounded
store calls at worst), finite so `Stop`'s exposure is one budget for the one
in-flight job. `TestWorker_StopCompletesWithNoEventConsumer` pins that
directly — `Stop` returns against a permanently full buffer with no reader.

**On the consumer's shape** (`drainWorkerEvents` / `flushWorkerEvents` / `Stop`,
read but not modified): neither flush is a reader the producer's new wait can
pre-empt, because `worker.Stop()` runs first in the #78 ordering — the producer
is finished before either flush begins.

**The failure mode also improves,** which is worth more than the drop it
prevents. Under a stalled consumer the worker now parks instead of racing ahead,
so the queue fills, `Enqueue` reports it, and Put's backpressure path (#79)
surfaces to writers what used to be invisible. Confirmed: pre-fix the worker
transferred all 12 objects and told the coordinator about none; it now transfers
at most one and leaves the backlog in the queue.

**If a terminal event is still lost it is observable.** `slog.Error` naming both
consequences, plus `DroppedTerminalEvents()`, a monotonic counter, so the loss
survives the log scrolling. It lives on the `Worker` rather than incrementing
Prometheus here because `internal/replication` does not import
`internal/metrics` and should not; wiring it to a counter is the coordinator's
job and is left as follow-up.

## Verified

Seven tests added. Six confirmed failing against the prior behaviour (sizing
reverted to `depth`, `emit` restored to the single non-blocking select, symbols
kept — so these are assertion failures, not compile errors):

```
terminal events for "e.bam": got 0, want exactly 1     (also f, g, h)
jobs with a terminal event: got 4, want 8 (buffer cap 8)
eventBufferSize(8) = 8, want >= 16 (2 events per job)
EventStarted took a reserved slot: buffered 3 -> 4 (cap 4)
emit gave up after 634.625micros, want >= the 50ms budget
the delayed EventCompleted was never delivered
DroppedTerminalEvents: got 0, want 1
the terminal event of a job settling during Stop was never delivered
worker transferred 12 of 12 objects while its event consumer was stalled
```

`TestWorker_StopCompletesWithNoEventConsumer` passes pre-fix by construction —
it is the regression a careless version of this change would introduce.

```
go build ./...                                 ok
go vet ./...                                   ok
gofmt -l .                                     (empty)
go test -race -timeout=8m ./...                all 16 packages ok
golangci-lint run --new-from-merge-base=main   0 issues.
go test -race -count=5 -cpu=1,2,4 ./internal/replication/    ok  31.4s
go test -race -count=5 -cpu=1,2,4 ./internal/coordinator/ ./cmd/coordinator/    ok
```

## Boundaries respected

`Start` and `Stop` in `worker.go` are untouched (#84's owner). No changes to
`internal/coordinator/*`, `cmd/coordinator/*`, `pkg/client/*`, `internal/cache/*`,
`internal/circuitbreaker/*`, or `CHANGELOG.md`. The queue-depth/concurrency
conflation in the daemon is left alone as the separate known issue it is.

Do not merge.