### PR TITLE
fix: v0.2.3 API follow-ups (#130, #131, #132)

### DIFF
--- a/cmd/coordinator/api.go
+++ b/cmd/coordinator/api.go
@@ -490,6 +490,58 @@ func sitesListHandler(c *coordinator.Coordinator) http.HandlerFunc {
 	}
 }
 
+// siteNameTaken reports whether a site with this name is already registered.
+//
+// This is an advisory pre-check only, and it races by construction: two
+// concurrent requests for one name can both see false.  Its job is to avoid the
+// pointless HeadBucket that site.NewFromConfig performs — a duplicate request
+// otherwise pays a full network round trip, and the coordinator signs an
+// outbound request with its own credentials, before learning the name is taken
+// (#131).  The decision that actually holds is AddSiteUnique's, which does the
+// check and the append under one lock hold.
+func siteNameTaken(c *coordinator.Coordinator, name string) bool {
+	for _, s := range c.Sites() {
+		if s.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// duplicateSiteMessage is the 409 body for a name that is already registered.
+// It names no more than the caller already knows: that the name is taken.
+const duplicateSiteMessage = "a site with that name is already registered"
+
+// registerSite adds mount to the coordinator, closing mount if it is rejected.
+//
+// AddSiteUnique, not AddSite: site names are the only handle RemoveSite,
+// Replicate and the health report have on a site, so two sites answering to one
+// name is an ambiguity none of them can resolve (#80).  The check and the append
+// happen under a single lock hold inside AddSiteUnique, which is what makes this
+// — and not addSiteHandler's cheap pre-check — the authoritative decision.
+//
+// Closing the rejected mount is this function's reason for existing.
+// AddSiteUnique deliberately leaves a rejected site open, on the grounds that
+// whoever constructed it decides its fate; here the mount is unreachable the
+// moment it is rejected, so not closing it leaks the S3 connection pool
+// site.NewFromConfig opened — #80's leak arriving by a new route (#131).  A close
+// error is logged and not returned: the registration outcome is what the caller
+// must act on, and a failed close cannot be retried by anyone.
+//
+// It is a function rather than inline handler code so the reject-and-close path
+// is reachable from a test.  Everything in the handler above it needs a real S3
+// endpoint to get as far as a *site.SiteMount; this takes one directly.
+func registerSite(c *coordinator.Coordinator, mount *site.SiteMount) error {
+	err := c.AddSiteUnique(mount)
+	if err == nil {
+		return nil
+	}
+	if cerr := mount.Close(); cerr != nil {
+		slog.Warn("api: add site: close rejected site", "name", mount.Name(), "error", cerr)
+	}
+	return err
+}
+
 // addSiteHandler handles POST /api/v1/sites — register a new site at runtime.
 //
 // sec constrains which s3_endpoint values are accepted; see validateS3Endpoint.
@@ -524,6 +576,16 @@ func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator, sec c
 		case types.SiteRolePrimary, types.SiteRoleBackup, types.SiteRoleBurst:
 		default:
 			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid role %q (primary|backup|burst)", req.Role))
+			return
+		}
+
+		// Reject a name that is already taken before resolving or connecting to
+		// anything.  Advisory and racy — see siteNameTaken — but it is what keeps a
+		// duplicate request from costing a DNS lookup and a signed HeadBucket
+		// against a caller-supplied endpoint for a request that cannot succeed
+		// (#131).  AddSiteUnique below is the check that decides.
+		if siteNameTaken(c, req.Name) {
+			writeError(w, http.StatusConflict, duplicateSiteMessage)
 			return
 		}
 
@@ -569,7 +631,22 @@ func addSiteHandler(daemonCtx context.Context, c *coordinator.Coordinator, sec c
 			return
 		}
 
-		c.AddSite(mount)
+		// registerSite closes the mount if it is rejected; see its doc comment for
+		// why the close belongs to this side of the boundary (#131).
+		if err := registerSite(c, mount); err != nil {
+			if errors.Is(err, coordinator.ErrDuplicateSite) {
+				slog.Warn("api: add site: duplicate name",
+					"name", req.Name,
+					"request_id", requestIDFromCtx(r.Context()),
+					"remote_addr", r.RemoteAddr,
+				)
+				writeError(w, http.StatusConflict, duplicateSiteMessage)
+				return
+			}
+			slog.Error("api: add site failed", "name", req.Name, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to add site")
+			return
+		}
 		slog.Info("api: site added", "name", req.Name, "role", req.Role)
 
 		writeJSON(w, http.StatusCreated, coordinator.SiteInfo{

--- a/cmd/coordinator/api.go
+++ b/cmd/coordinator/api.go
@@ -281,6 +281,41 @@ type errorResponse struct {
 	Error string `json:"error"`
 }
 
+// objectPutPartialResponse is the body of a 202 from PUT /api/v1/objects/{key...}:
+// the object is stored on every primary and readable, but replication to one or
+// more secondaries could not be queued (#130).
+//
+// It is deliberately not an errorResponse.  A 202 is not an error, and a client
+// that keys off `{"error": ...}` to decide whether a request failed would read
+// this success as a failure — which is the mistake the whole issue is about,
+// moved from the status code into the body.
+//
+// Detail carries the coordinator's own message, which names the destinations that
+// got no job.  They are not broken out into a field because the only way to
+// obtain them here is to parse a formatted error string, and a parser of another
+// package's %v output is a silent breakage waiting for the next edit to that
+// format.  Exposing them structurally needs a typed error from
+// internal/coordinator; until then Detail is verbatim and the header below is the
+// part a machine should read.
+type objectPutPartialResponse struct {
+	Key    string `json:"key"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// replicationHeader marks a response whose write is stored but not fully
+// replicated, so the condition is visible without parsing the body — the same
+// role X-GlobalFS-Partial plays for the 207 on the list path (#33/#104).
+//
+// A header is what a proxy, an access log, or a metrics pipeline can act on; a
+// 202 alone is ambiguous (replicateHandler returns one for an ordinary success)
+// and a JSON field requires reading a body those layers do not have.
+const replicationHeader = "X-GlobalFS-Replication"
+
+// replicationPending is the replicationHeader value for a stored-but-unreplicated
+// write.
+const replicationPending = "pending"
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 func writeJSON(w http.ResponseWriter, code int, v any) {
@@ -860,6 +895,32 @@ func objectPutHandler(c *coordinator.Coordinator) http.HandlerFunc {
 		}
 
 		if err := c.Put(r.Context(), key, data); err != nil {
+			// ErrReplicationNotQueued is a partial success, not a failure: the bytes
+			// are durably on every primary in the routed set and the object is
+			// readable immediately, and only replication to the named secondaries
+			// was not queued.  Reporting that as 502 tells a caller following normal
+			// practice to retry a write that already committed, and makes a queue
+			// backlog look like an outage to anything alerting on 5xx (#130).
+			//
+			// 202 Accepted, because the request was accepted and acted on with
+			// processing outstanding.  Retrying the identical PUT is safe — the
+			// primary write is idempotent and the coordinator skips destinations
+			// that already hold the content hash — so a client that treats 202 as
+			// "retry later" is also correct, just redundant.
+			if errors.Is(err, coordinator.ErrReplicationNotQueued) {
+				slog.Warn("api: object stored but replication not queued",
+					"key", key,
+					"bytes", len(data),
+					"request_id", requestIDFromCtx(r.Context()),
+					"error", err)
+				w.Header().Set(replicationHeader, replicationPending)
+				writeJSON(w, http.StatusAccepted, objectPutPartialResponse{
+					Key:    key,
+					Status: "stored; replication incomplete",
+					Detail: err.Error(),
+				})
+				return
+			}
 			writeError(w, http.StatusBadGateway, err.Error())
 			return
 		}

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -41,6 +42,12 @@ type testMemClient struct {
 	// payload large enough to be slow on its own merits (#75). Set before the
 	// client is handed to a coordinator; not mutated afterwards.
 	getDelay time.Duration
+
+	// putGate, when non-nil, parks every Put until it is closed.  Used to hold the
+	// single replication worker inside a transfer so the replication queue fills
+	// and stays full, which is the only way to reach ErrReplicationNotQueued from
+	// a handler test (#130).
+	putGate chan struct{}
 }
 
 func newTestMemClient(objs map[string][]byte) *testMemClient {
@@ -69,6 +76,12 @@ func (m *testMemClient) Get(_ context.Context, key string, _, _ int64) ([]byte, 
 }
 
 func (m *testMemClient) Put(_ context.Context, key string, data []byte) error {
+	m.mu.Lock()
+	gate := m.putGate
+	m.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
 	if m.putErr != nil {
 		return m.putErr
 	}
@@ -78,6 +91,17 @@ func (m *testMemClient) Put(_ context.Context, key string, data []byte) error {
 	copy(cp, data)
 	m.objects[key] = cp
 	return nil
+}
+
+// blockPuts parks every subsequent Put on this client.  The returned release
+// function is safe to call more than once.
+func (m *testMemClient) blockPuts() (release func()) {
+	gate := make(chan struct{})
+	m.mu.Lock()
+	m.putGate = gate
+	m.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
 }
 
 func (m *testMemClient) Delete(_ context.Context, key string) error {
@@ -144,6 +168,13 @@ func (m *testMemClient) hasKey(key string) bool {
 	defer m.mu.Unlock()
 	_, ok := m.objects[key]
 	return ok
+}
+
+// keyCount returns how many objects this client holds.
+func (m *testMemClient) keyCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.objects)
 }
 
 // ── Test coordinator factory ──────────────────────────────────────────────────
@@ -333,6 +364,131 @@ func TestObjectPut_CoordinatorError(t *testing.T) {
 	objectPutHandler(c)(w, req)
 	if w.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+// ── objectPutHandler: replication queue saturated (#130) ──────────────────────
+
+// makeSaturatedReplicationCoordinator returns a coordinator whose replication
+// queue is permanently full: a primary that accepts writes, a backup whose Put
+// never returns, and a worker queue of depth 1 that the parked worker therefore
+// never drains.  Put's backpressure budget is set short so the handler does not
+// wait the default 2 s.
+//
+// The two cleanups are registered in this order deliberately.  t.Cleanup runs
+// LIFO, so release runs before Stop — Stop against a worker parked inside Put
+// hangs the test rather than failing it (#83).
+func makeSaturatedReplicationCoordinator(t *testing.T) (*coordinator.Coordinator, *testMemClient) {
+	t.Helper()
+
+	primaryClient := newTestMemClient(nil)
+	backupClient := newTestMemClient(nil)
+	release := backupClient.blockPuts()
+
+	c := coordinator.New(
+		site.New("primary", types.SiteRolePrimary, primaryClient),
+		site.New("backup", types.SiteRoleBackup, backupClient),
+	)
+	c.SetWorkerQueueDepth(1)
+	c.SetEnqueueBackpressure(20 * time.Millisecond)
+	c.Start(context.Background())
+	t.Cleanup(c.Stop)
+	t.Cleanup(release)
+
+	return c, primaryClient
+}
+
+// TestObjectPut_ReplicationNotQueued_Returns202 is the #130 assertion: a write
+// whose bytes are durable on the primary but whose replication could not be
+// queued is a partial success, and answering 502 tells a caller to retry a write
+// that already committed while making a queue backlog look like an outage.
+func TestObjectPut_ReplicationNotQueued_Returns202(t *testing.T) {
+	c, primaryClient := makeSaturatedReplicationCoordinator(t)
+
+	// The first PUT is queued (depth 1) and the worker picks it up and parks in
+	// the backup's Put, so the queue is full from the second onwards.  Loop until
+	// one PUT is refused rather than assuming which: the worker may not have
+	// dequeued the first job yet.
+	var w *httptest.ResponseRecorder
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("data/obj-%02d", i)
+		req := httptest.NewRequest("PUT", "/api/v1/objects/"+key,
+			bytes.NewReader([]byte("payload")))
+		req.SetPathValue("key", key)
+		rec := httptest.NewRecorder()
+		objectPutHandler(c)(rec, req)
+		if rec.Code != http.StatusCreated {
+			w = rec
+			break
+		}
+	}
+	if w == nil {
+		t.Fatal("no PUT hit a full replication queue after 10 attempts; " +
+			"the queue is being drained and the test cannot observe #130")
+	}
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("replication queue full: got %d, want 202 — a write stored on every "+
+			"primary is a partial success, not a gateway failure (#130): %s",
+			w.Code, w.Body.String())
+	}
+
+	// The condition has to be readable without parsing the body, in the way the
+	// 207 list path uses X-GlobalFS-Partial.
+	if got := w.Header().Get("X-GlobalFS-Replication"); got != "pending" {
+		t.Errorf("X-GlobalFS-Replication = %q, want %q", got, "pending")
+	}
+
+	// The body must not be an errorResponse: a client keying off {"error":...} to
+	// decide whether the request failed would read this success as a failure,
+	// which is the same defect moved from the status code into the body.
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("202 body is not JSON: %v (%s)", err, w.Body.String())
+	}
+	if _, ok := body["error"]; ok {
+		t.Errorf("202 body carries an \"error\" field: %s", w.Body.String())
+	}
+	for _, field := range []string{"key", "status", "detail"} {
+		if _, ok := body[field]; !ok {
+			t.Errorf("202 body is missing %q: %s", field, w.Body.String())
+		}
+	}
+	// The detail must name what is incomplete, since that is what an operator acts
+	// on and the coordinator's message already carries the destinations.
+	if detail, _ := body["detail"].(string); !strings.Contains(detail, "backup") {
+		t.Errorf("202 detail does not name the un-queued destination: %q", detail)
+	}
+
+	// The whole justification for 202 is that the bytes are on the primary.  If
+	// they are not, 202 would be the lie 201 used to be.
+	if primaryClient.keyCount() == 0 {
+		t.Error("no object reached the primary; a 202 here would be as wrong as the old 201")
+	}
+}
+
+// TestObjectPut_PrimaryFailureStillReturns502 pins the other side of the branch:
+// only ErrReplicationNotQueued becomes a 202.  A primary write that genuinely
+// failed has stored nothing and must stay a 502, or #130's fix converts every
+// write failure into a reported success.
+func TestObjectPut_PrimaryFailureStillReturns502(t *testing.T) {
+	c, mc := makeTestCoordinator(t, nil)
+	mc.putErr = errors.New("disk full")
+
+	req := httptest.NewRequest("PUT", "/api/v1/objects/data/x",
+		bytes.NewReader([]byte("payload")))
+	req.SetPathValue("key", "data/x")
+	w := httptest.NewRecorder()
+	objectPutHandler(c)(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("primary write failure: got %d, want 502: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-GlobalFS-Replication"); got != "" {
+		t.Errorf("X-GlobalFS-Replication set to %q on a failed write", got)
+	}
+	if !strings.Contains(w.Body.String(), "error") {
+		t.Errorf("502 body is not an error envelope: %s", w.Body.String())
 	}
 }
 

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/scttfrdmn/globalfs/internal/circuitbreaker"
 	"github.com/scttfrdmn/globalfs/internal/coordinator"
+	"github.com/scttfrdmn/globalfs/pkg/client"
 	"github.com/scttfrdmn/globalfs/pkg/config"
 	"github.com/scttfrdmn/globalfs/pkg/site"
 	"github.com/scttfrdmn/globalfs/pkg/types"
@@ -505,6 +506,56 @@ func TestObjectPut_PrimaryFailureStillReturns502(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "error") {
 		t.Errorf("502 body is not an error envelope: %s", w.Body.String())
+	}
+}
+
+// TestObjectPut_ReplicationNotQueued_RoundTripsToClient closes #130 end to end.
+//
+// The two tests above assert what the coordinator emits, and pkg/client's tests
+// assert what it does with a 202 from a stub.  Neither shows that the real
+// handler and the real client agree, and that gap is exactly where #130 survived
+// its first fix: the coordinator started returning 202 while PutObject still
+// required an exact 201, so the defect reached the CLI unchanged.  This drives
+// the actual handler over a real socket with the actual client, so a future
+// change to either side that breaks the contract fails here.
+func TestObjectPut_ReplicationNotQueued_RoundTripsToClient(t *testing.T) {
+	c, _ := makeSaturatedReplicationCoordinator(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", objectPutHandler(c))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cl := client.New(srv.URL)
+
+	// As in the handler test: loop until one write hits the full queue, since the
+	// worker may not have dequeued the first job yet.
+	var err error
+	for i := 0; i < 10; i++ {
+		err = cl.PutObject(context.Background(), fmt.Sprintf("data/rt-%02d", i), []byte("payload"))
+		if err != nil {
+			break
+		}
+	}
+	if err == nil {
+		t.Fatal("no PUT hit a full replication queue after 10 attempts; " +
+			"the queue is being drained and the test cannot observe #130")
+	}
+
+	if !errors.Is(err, client.ErrReplicationPending) {
+		t.Fatalf("the coordinator's 202 did not reach the client as ErrReplicationPending: %#v (%v)", err, err)
+	}
+	// A committed write must not look like a failed request to a caller switching
+	// on *APIError — that is what made the CLI print "error" for durable bytes.
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) {
+		t.Errorf("the 202 arrived as *APIError (status %d): a committed write reported as a failure",
+			apiErr.StatusCode)
+	}
+	// And the coordinator's detail survives the trip, so an operator can see which
+	// site is behind.
+	if !strings.Contains(err.Error(), "backup") {
+		t.Errorf("the coordinator's detail was lost in transit (should name the un-queued site): %v", err)
 	}
 }
 

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -196,12 +196,36 @@ func (m *testMemClient) keyCount() int {
 
 // ── Test coordinator factory ──────────────────────────────────────────────────
 
+// mustStart starts c and fails the test if the coordinator refuses.
+//
+// Discarding this error is not cosmetic in a test: Start returning ErrStopped
+// leaves a coordinator with no replication worker and no health poller, and every
+// assertion below would then run against a daemon that is not running.  A test
+// that passes in that state is worse than one that fails, because it reports the
+// handler as working when nothing behind it is.
+func mustStart(t *testing.T, c *coordinator.Coordinator) {
+	t.Helper()
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("coordinator.Start: %v", err)
+	}
+}
+
+// mustSet fails the test if a coordinator configuration call was refused, for the
+// same reason mustConfigure exits the daemon: the setting silently reverts to a
+// default and the test then measures the default instead of the value it set.
+func mustSet(t *testing.T, what string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("coordinator configuration %s was refused: %v", what, err)
+	}
+}
+
 func makeTestCoordinator(t *testing.T, objs map[string][]byte) (*coordinator.Coordinator, *testMemClient) {
 	t.Helper()
 	mc := newTestMemClient(objs)
 	s := site.New("primary", types.SiteRolePrimary, mc)
 	c := coordinator.New(s)
-	c.Start(context.Background())
+	mustStart(t, c)
 	t.Cleanup(c.Stop)
 	return c, mc
 }
@@ -406,9 +430,9 @@ func makeSaturatedReplicationCoordinator(t *testing.T) (*coordinator.Coordinator
 		site.New("primary", types.SiteRolePrimary, primaryClient),
 		site.New("backup", types.SiteRoleBackup, backupClient),
 	)
-	c.SetWorkerQueueDepth(1)
+	mustSet(t, "worker queue depth", c.SetWorkerQueueDepth(1))
 	c.SetEnqueueBackpressure(20 * time.Millisecond)
-	c.Start(context.Background())
+	mustStart(t, c)
 	t.Cleanup(c.Stop)
 	t.Cleanup(release)
 
@@ -1070,7 +1094,7 @@ func TestInfoHandler_SitesCounted(t *testing.T) {
 	s1 := site.New("primary", types.SiteRolePrimary, mc1)
 	s2 := site.New("backup", types.SiteRoleBackup, mc2)
 	c := coordinator.New(s1, s2)
-	c.Start(context.Background())
+	mustStart(t, c)
 	t.Cleanup(c.Stop)
 
 	req := httptest.NewRequest("GET", "/api/v1/info", nil)
@@ -1145,8 +1169,8 @@ func TestInfoHandler_HealthSummary_AfterPoll(t *testing.T) {
 	mc := newTestMemClient(nil)
 	s := site.New("primary", types.SiteRolePrimary, mc)
 	c := coordinator.New(s)
-	c.SetHealthPollInterval(10 * time.Millisecond)
-	c.Start(context.Background())
+	mustSet(t, "health poll interval", c.SetHealthPollInterval(10*time.Millisecond))
+	mustStart(t, c)
 	t.Cleanup(c.Stop)
 
 	// Wait for the first poll.
@@ -1180,8 +1204,8 @@ func TestHealthzHandler_UsesCachedHealth(t *testing.T) {
 	mc := newTestMemClient(nil)
 	s := site.New("primary", types.SiteRolePrimary, mc)
 	c := coordinator.New(s)
-	c.SetHealthPollInterval(10 * time.Millisecond)
-	c.Start(context.Background())
+	mustSet(t, "health poll interval", c.SetHealthPollInterval(10*time.Millisecond))
+	mustStart(t, c)
 	t.Cleanup(c.Stop)
 
 	// Wait for at least one poll.
@@ -1227,8 +1251,8 @@ func TestHealthzHandler_CacheDegradedSite(t *testing.T) {
 	mc.healthErr = errors.New("disk full")
 	s := site.New("primary", types.SiteRolePrimary, mc)
 	c := coordinator.New(s)
-	c.SetHealthPollInterval(10 * time.Millisecond)
-	c.Start(context.Background())
+	mustSet(t, "health poll interval", c.SetHealthPollInterval(10*time.Millisecond))
+	mustStart(t, c)
 	t.Cleanup(c.Stop)
 
 	// Wait for cache to reflect the error.

--- a/cmd/coordinator/api_test.go
+++ b/cmd/coordinator/api_test.go
@@ -48,6 +48,10 @@ type testMemClient struct {
 	// and stays full, which is the only way to reach ErrReplicationNotQueued from
 	// a handler test (#130).
 	putGate chan struct{}
+
+	// closes counts Close calls, so a test can assert that a site whose
+	// registration was rejected had its connection pool released (#131).
+	closes int
 }
 
 func newTestMemClient(objs map[string][]byte) *testMemClient {
@@ -161,7 +165,19 @@ func (m *testMemClient) Health(_ context.Context) error {
 	defer m.mu.Unlock()
 	return m.healthErr
 }
-func (m *testMemClient) Close() error { return nil }
+func (m *testMemClient) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closes++
+	return nil
+}
+
+// closeCount returns how many times Close has been called on this client.
+func (m *testMemClient) closeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closes
+}
 
 func (m *testMemClient) hasKey(key string) bool {
 	m.mu.Lock()
@@ -1257,6 +1273,160 @@ func TestAddSite_InvalidJSON(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("invalid JSON: expected 400, got %d", w.Code)
+	}
+}
+
+// ── addSiteHandler: duplicate site name (#131) ─────────────────────────────────
+
+// TestAddSite_DuplicateName_Returns409 is the #131 assertion at the handler
+// boundary: a POST naming an already-registered site must be refused, and refused
+// before it costs a DNS lookup and a signed HeadBucket against the caller's
+// endpoint.
+//
+// The victim listener is the proof of the second half.  Pre-fix the handler
+// reached site.NewFromConfig — and so an outbound request — before it would have
+// discovered the name was taken; the assertion is a request count of zero, the
+// same shape TestAddSite_EndpointRejected_NoSignedRequestSent uses for #76.  It
+// is allowlisted so that only the SSRF address checks are out of the way and the
+// duplicate check is what is being measured.
+func TestAddSite_DuplicateName_Returns409(t *testing.T) {
+	var mu sync.Mutex
+	var received int
+
+	victim := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		received++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer victim.Close()
+
+	// makeTestCoordinator registers exactly one site, named "primary".
+	c, _ := makeTestCoordinator(t, nil)
+
+	host, _, err := net.SplitHostPort(strings.TrimPrefix(victim.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split victim addr: %v", err)
+	}
+	sec := config.SecurityConfig{AllowedEndpointHosts: []string{host}}
+
+	body := `{"name":"primary","s3_bucket":"bucket","s3_region":"us-east-1","s3_endpoint":"` + victim.URL + `"}`
+	req := httptest.NewRequest("POST", "/api/v1/sites", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	addSiteHandler(context.Background(), c, sec)(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate site name: got %d, want 409 — two sites sharing a name is a "+
+			"state no operation can address unambiguously (#131): %s", w.Code, w.Body.String())
+	}
+
+	// Exactly one site retained: not zero (the existing one must survive a
+	// rejected duplicate) and not two.
+	if got := len(c.Sites()); got != 1 {
+		t.Errorf("coordinator holds %d sites after a rejected duplicate, want 1", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if received != 0 {
+		t.Errorf("the handler sent %d request(s) to the endpoint for a POST that cannot "+
+			"succeed; the name check has to come before the connect (#131)", received)
+	}
+}
+
+// TestRegisterSite_RejectedMountIsClosed covers the part of #131 the handler
+// cannot reach in a test: everything above registerSite needs a real S3 endpoint
+// to produce a *site.SiteMount at all.
+//
+// AddSiteUnique deliberately does not close a site it rejects, so if this side
+// does not either, the connection pool site.NewFromConfig opened is leaked — #80's
+// leak arriving on a new path.  The assertion is therefore a close count, not a
+// status code.
+func TestRegisterSite_RejectedMountIsClosed(t *testing.T) {
+	c, firstClient := makeTestCoordinator(t, nil)
+
+	dupClient := newTestMemClient(nil)
+	dup := site.New("primary", types.SiteRolePrimary, dupClient)
+
+	err := registerSite(c, dup)
+	if err == nil {
+		t.Fatal("registerSite accepted a duplicate name")
+	}
+	if !errors.Is(err, coordinator.ErrDuplicateSite) {
+		t.Errorf("error does not wrap ErrDuplicateSite, so the handler cannot map it to 409: %v", err)
+	}
+	if got := dupClient.closeCount(); got != 1 {
+		t.Errorf("rejected mount closed %d times, want 1 — an unclosed mount leaks the "+
+			"S3 connection pool NewFromConfig opened (#80/#131)", got)
+	}
+	// The site that was already registered must not be disturbed.
+	if got := firstClient.closeCount(); got != 0 {
+		t.Errorf("the retained site was closed %d times; only the rejected mount may be closed", got)
+	}
+	if got := len(c.Sites()); got != 1 {
+		t.Errorf("coordinator holds %d sites, want 1", got)
+	}
+}
+
+// TestRegisterSite_AcceptedMountIsNotClosed is the other half: a successful
+// registration must not close the site it just handed to the coordinator.  A
+// close-on-every-path implementation would pass the test above and leave the
+// coordinator holding a site whose client is shut.
+func TestRegisterSite_AcceptedMountIsNotClosed(t *testing.T) {
+	c, _ := makeTestCoordinator(t, nil)
+
+	mc := newTestMemClient(nil)
+	if err := registerSite(c, site.New("burst", types.SiteRoleBurst, mc)); err != nil {
+		t.Fatalf("registerSite: %v", err)
+	}
+	if got := mc.closeCount(); got != 0 {
+		t.Errorf("accepted mount was closed %d times; the coordinator now owns a dead client", got)
+	}
+	if got := len(c.Sites()); got != 2 {
+		t.Errorf("coordinator holds %d sites, want 2", got)
+	}
+}
+
+// TestAddSite_ConcurrentDuplicates_OnlyOneWins pins the reason the cheap
+// pre-check is not the authoritative one.  siteNameTaken races by construction:
+// every request here can observe an unused name before any of them registers it,
+// so if AddSiteUnique were not the deciding check this would leave several sites
+// answering to one name.
+func TestAddSite_ConcurrentDuplicates_OnlyOneWins(t *testing.T) {
+	c, _ := makeTestCoordinator(t, nil)
+
+	const n = 16
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	accepted := 0
+	closed := 0
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mc := newTestMemClient(nil)
+			err := registerSite(c, site.New("contended", types.SiteRoleBackup, mc))
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				accepted++
+			}
+			closed += mc.closeCount()
+		}()
+	}
+	wg.Wait()
+
+	if accepted != 1 {
+		t.Errorf("%d of %d concurrent registrations of one name were accepted, want 1", accepted, n)
+	}
+	if closed != n-1 {
+		t.Errorf("%d rejected mounts were closed, want %d — every rejection leaks a "+
+			"connection pool otherwise", closed, n-1)
+	}
+	// One pre-existing "primary" plus exactly one "contended".
+	if got := len(c.Sites()); got != 2 {
+		t.Errorf("coordinator holds %d sites, want 2", got)
 	}
 }
 

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -48,6 +48,69 @@ import (
 // never reports a real release version.
 var version = "dev"
 
+// coordinatorShutdownTimeout bounds coordinator teardown after the HTTP server
+// has drained.  It is the outer half of #83: the coordinator bounds its own
+// waits, and this bounds the whole of CloseContext including the site closes that
+// follow the stop, so SIGTERM returns even if a site's connection-pool drain
+// never does.
+//
+// 30 s matches internal/coordinator's own defaultStopTimeout and the HTTP drain
+// window above, which keeps the worst case a caller has to reason about at two
+// windows rather than three.  See newShutdownContext for why this is still
+// load-bearing rather than redundant with the coordinator's own default.
+const coordinatorShutdownTimeout = 30 * time.Second
+
+// newShutdownContext returns the context used to bound coordinator teardown.
+//
+// It deliberately derives from context.Background() and *not* from the daemon's
+// root context, which the shutdown path has already cancelled.  A context derived
+// from a cancelled parent is born cancelled — Err() is non-nil immediately — so
+// passing one to CloseContext would make every bounded wait inside it return at
+// once: Worker.StopContext would abandon the in-flight transfer instead of
+// letting it settle, and its terminal event would go unemitted with the drain
+// already gone.  That is exactly the phantom-job condition #78 fixed, so
+// deriving here would reintroduce it while appearing to add a safety bound.
+//
+// The cancellation of the root context is still what tells the worker's run loop
+// to stop accepting new jobs; the point is that the *deadline for observing the
+// current one finishing* has to be independent of it.
+//
+// This is a function rather than three inline lines so the derivation can be
+// asserted in a test.  It is the kind of detail that reads as obviously correct
+// either way and is only obviously wrong at 3 a.m. during a rolling restart.
+func newShutdownContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), coordinatorShutdownTimeout)
+}
+
+// mustConfigure exits the daemon if a coordinator configuration call was refused.
+//
+// Every Set* call in main runs during boot, before Start, where the coordinator's
+// contract is to return nil.  A non-nil error therefore cannot be caused by
+// anything the operator wrote in the config file: it means the call arrived after
+// Start, which at this point in main is unreachable and so is a programming error
+// in this file — a reordering that moved a setter below Start.
+//
+// It is fatal rather than logged-and-continued because the failure is otherwise
+// invisible in the way that matters.  The value came from the config file, so
+// `config show` would keep reporting it while the daemon ran on the default —
+// exactly the divergence between reported and effective configuration that #81
+// and the yaml-tag bug produced, and the reason those were worth fixing.  A
+// deployment is better off failing to start than running with a queue depth, a
+// lease TTL, or a health cadence that nobody chose.
+//
+// The label is the operator-facing name of the setting rather than the Go method,
+// since the person reading the log is likelier to be holding the YAML than the
+// source.  internal/coordinator also logs the method name itself.
+func mustConfigure(what string, err error) {
+	if err == nil {
+		return
+	}
+	slog.Error("coordinator configuration was refused; this is a bug in the daemon's boot order, "+
+		"not a problem with your configuration file",
+		"setting", what, "error", err)
+	os.Exit(1)
+}
+
 func main() {
 	configPath := flag.String("config", "", "Path to YAML configuration file")
 	logLevelStr := flag.String("log-level", "INFO", "Log level: DEBUG, INFO, WARN, ERROR")
@@ -130,17 +193,18 @@ func main() {
 	c := coordinator.New(mounts...)
 
 	m := metrics.New(prometheus.DefaultRegisterer)
-	c.SetMetrics(m)
+	mustConfigure("metrics", c.SetMetrics(m))
 
 	// ── Leader lease TTL (from coordinator.lease_timeout) ─────────────────────
 	if cfg.Coordinator.LeaseTimeout > 0 {
-		c.SetLeaseTTL(cfg.Coordinator.LeaseTimeout)
+		mustConfigure("leader lease TTL", c.SetLeaseTTL(cfg.Coordinator.LeaseTimeout))
 		slog.Info("leader lease TTL configured", "ttl", cfg.Coordinator.LeaseTimeout)
 	}
 
 	// ── Replication worker queue depth (from performance.max_concurrent_transfers) ─
 	if cfg.Performance.MaxConcurrentTransfers > 0 {
-		c.SetWorkerQueueDepth(cfg.Performance.MaxConcurrentTransfers)
+		mustConfigure("replication worker queue depth",
+			c.SetWorkerQueueDepth(cfg.Performance.MaxConcurrentTransfers))
 		slog.Info("replication worker depth configured", "depth", cfg.Performance.MaxConcurrentTransfers)
 	}
 
@@ -156,7 +220,7 @@ func main() {
 		}
 	}
 	if healthPoll > 0 {
-		c.SetHealthPollInterval(healthPoll)
+		mustConfigure("health poll interval", c.SetHealthPollInterval(healthPoll))
 		slog.Info("health polling configured", "interval", healthPoll)
 	}
 
@@ -232,7 +296,18 @@ func main() {
 		slog.Info("policy engine loaded", "rules", len(cfg.Policy.Rules))
 	}
 
-	c.Start(ctx)
+	// A refused Start is fatal.  Under the lifecycle contract Start returns an
+	// error wrapping ErrStopped, and a daemon that continued past it would serve
+	// HTTP with no replication worker and no health poller: writes would reach
+	// primaries and be reported as stored, /healthz would answer from a cache
+	// nothing refreshes, and nothing in the log would say why.  That is #84's
+	// silent-standby failure with a process supervisor keeping it alive.  Exiting
+	// non-zero lets the supervisor restart into a fresh coordinator, which is the
+	// only recovery a single-use lifecycle allows.
+	if err := c.Start(ctx); err != nil {
+		slog.Error("failed to start coordinator", "error", err)
+		os.Exit(1)
+	}
 	slog.Info("coordinator started",
 		"sites", len(mounts),
 		"cluster", cfg.Global.ClusterName,
@@ -287,8 +362,13 @@ func main() {
 	sig := <-sigCh
 	slog.Info("shutdown signal received", "signal", sig)
 
-	// Stop accepting new HTTP requests (30s drain window).
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Stop accepting new HTTP requests.  Same budget as the coordinator teardown
+	// below, and the two are sequential, so the worst-case time from signal to exit
+	// is 2 × coordinatorShutdownTimeout.  That matters for the termination grace
+	// period configured in whatever supervises this process: at 60 s total it must
+	// be higher than that, or the supervisor's SIGKILL arrives first and the
+	// bounded shutdown never gets to run.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), coordinatorShutdownTimeout)
 	defer shutdownCancel()
 
 	exitCode := 0
@@ -298,11 +378,27 @@ func main() {
 		exitCode = 1
 	}
 
-	// Cancel the main context so the replication worker exits its loop,
-	// then stop the coordinator (waits for the current job to finish).
+	// Cancel the main context so the replication worker stops taking new jobs,
+	// then tear the coordinator down under a bound of our own.
+	//
+	// c.Close() would self-bound at the same 30 s, but the budget has to start
+	// here rather than inside: Close's own default begins when Close is entered,
+	// which is fine today and stops being fine the moment anything is added
+	// between the cancel and the teardown.  Passing an explicit context also makes
+	// the deadline visible at the call site instead of being a property of the
+	// callee, and is the only way to make the derivation testable — see
+	// newShutdownContext for why it must not descend from the cancelled ctx.
 	cancel()
-	if err := c.Close(); err != nil {
-		slog.Error("error closing coordinator", "error", err)
+	closeCtx, closeCancel := newShutdownContext()
+	defer closeCancel()
+	if err := c.CloseContext(closeCtx); err != nil {
+		// Non-zero exit on a timed-out teardown is deliberate (#69's reasoning
+		// applied to #83): the process is terminating either way, but a transfer
+		// abandoned mid-flight or a site left unclosed is not a clean shutdown, and
+		// an orchestrator or an operator reading $? is entitled to know the
+		// difference.
+		slog.Error("error closing coordinator; shutdown was not clean",
+			"timeout", coordinatorShutdownTimeout, "error", err)
 		exitCode = 1
 	}
 

--- a/cmd/coordinator/main_test.go
+++ b/cmd/coordinator/main_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/globalfs/internal/coordinator"
+	"github.com/scttfrdmn/globalfs/pkg/site"
+	"github.com/scttfrdmn/globalfs/pkg/types"
+)
+
+// ── Shutdown context derivation (#83) ─────────────────────────────────────────
+
+// TestNewShutdownContext_IsNotDerivedFromCancelledRoot pins the detail that makes
+// the #83 fix correct rather than merely bounded.
+//
+// The shipped shutdown path cancels the daemon's root context and only then tears
+// the coordinator down.  A timeout context derived from that root is born
+// cancelled, so every bounded wait inside CloseContext would return immediately —
+// which looks like a successful fast shutdown and is actually the phantom-job
+// condition #78 fixed, since the in-flight transfer is abandoned before its
+// terminal event is emitted.
+//
+// The test asserts the correct behaviour *and* demonstrates the broken
+// alternative, so the reason the code is written this way survives in executable
+// form rather than only in a comment.
+func TestNewShutdownContext_IsNotDerivedFromCancelledRoot(t *testing.T) {
+	// Reproduce the daemon's state at the point of teardown.
+	root, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The broken alternative, to prove the hazard is real and not theoretical.
+	derived, derivedCancel := context.WithTimeout(root, coordinatorShutdownTimeout)
+	defer derivedCancel()
+	if derived.Err() == nil {
+		t.Fatal("a context derived from the cancelled root is NOT already cancelled; " +
+			"the premise of this test (and of newShutdownContext's comment) is wrong " +
+			"and the reasoning needs revisiting")
+	}
+
+	// The real thing must survive the root's cancellation.
+	ctx, ctxCancel := newShutdownContext()
+	defer ctxCancel()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("newShutdownContext returned an already-finished context (%v): "+
+			"every bounded wait in CloseContext would give up immediately and the "+
+			"in-flight transfer would be abandoned rather than settled (#78, #83)", err)
+	}
+
+	// And it must actually carry a deadline: StopContext and CloseContext only
+	// impose their own default when the caller supplies none, so a missing
+	// deadline here would silently move the bound back inside the coordinator.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("newShutdownContext has no deadline; SIGTERM would rely on the " +
+			"coordinator's internal default instead of the daemon's own bound")
+	}
+	if d := time.Until(deadline); d <= 0 || d > coordinatorShutdownTimeout+time.Second {
+		t.Errorf("deadline is %v away, want ~%v", d, coordinatorShutdownTimeout)
+	}
+}
+
+// ── Shutdown actually waits for the in-flight transfer ────────────────────────
+
+// parkedClient wraps testMemClient to announce when a Put has been *entered*,
+// which is what these tests need to synchronise on.
+//
+// Waiting for the key to appear instead would deadlock against the very gate that
+// makes the transfer in-flight: the whole point is that the Put does not finish.
+// entered is closed on the first Put, so the test can proceed the instant the
+// worker is genuinely parked rather than sleeping a guessed interval.
+type parkedClient struct {
+	*testMemClient
+	entered chan struct{}
+	once    sync.Once
+}
+
+func newParkedClient() *parkedClient {
+	return &parkedClient{
+		testMemClient: newTestMemClient(nil),
+		entered:       make(chan struct{}),
+	}
+}
+
+func (p *parkedClient) Put(ctx context.Context, key string, data []byte) error {
+	p.once.Do(func() { close(p.entered) })
+	return p.testMemClient.Put(ctx, key, data)
+}
+
+// waitParked blocks until a Put has been entered, or fails the test.
+func (p *parkedClient) waitParked(t *testing.T) {
+	t.Helper()
+	select {
+	case <-p.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no replication Put was entered; the worker never picked up the job " +
+			"and these tests cannot observe an in-flight transfer")
+	}
+}
+
+// TestShutdown_WaitsForInFlightTransfer is the behavioural half of #83: with the
+// context newShutdownContext produces, teardown waits for a parked transfer to
+// settle; with one derived from the cancelled root it does not.
+//
+// This is the assertion that would have caught the mistake, as opposed to the
+// derivation test above which only catches it if someone reads it.
+func TestShutdown_WaitsForInFlightTransfer(t *testing.T) {
+	newDaemon := func(t *testing.T) (*coordinator.Coordinator, *parkedClient, func()) {
+		t.Helper()
+		primary := newTestMemClient(nil)
+		backup := newParkedClient()
+		release := backup.blockPuts()
+
+		c := coordinator.New(
+			site.New("primary", types.SiteRolePrimary, primary),
+			site.New("backup", types.SiteRoleBackup, backup),
+		)
+		// The daemon's root context, which shutdown cancels before teardown.  Start
+		// takes it, so cancelling it is what stops the worker accepting new jobs —
+		// the same wiring main.go uses.
+		rootCtx, rootCancel := context.WithCancel(context.Background())
+		if err := c.Start(rootCtx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		// Put so the worker dequeues a job and parks inside the backup's Put.
+		if err := c.Put(context.Background(), "data/inflight", []byte("payload")); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		backup.waitParked(t)
+
+		rootCancel() // what main does before tearing down
+		return c, backup, release
+	}
+
+	t.Run("fresh context lets the transfer settle", func(t *testing.T) {
+		c, backup, release := newDaemon(t)
+
+		// Release shortly after teardown begins, so the wait is what decides
+		// whether the transfer completes.
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			release()
+		}()
+
+		// Same derivation as newShutdownContext, with a shorter budget so the test
+		// is fast; the property under test is the parentage, not the duration.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := c.CloseContext(ctx); err != nil {
+			t.Fatalf("CloseContext with a fresh context: %v (want nil: the transfer "+
+				"was given time to settle)", err)
+		}
+		if backup.keyCount() == 0 {
+			t.Error("the in-flight transfer never landed on the backup: shutdown " +
+				"abandoned it instead of letting it settle (#78)")
+		}
+	})
+
+	t.Run("context derived from the cancelled root abandons it", func(t *testing.T) {
+		c, backup, release := newDaemon(t)
+		t.Cleanup(release)
+
+		// The mistake newShutdownContext exists to prevent.
+		root, rootCancel := context.WithCancel(context.Background())
+		rootCancel()
+		ctx, cancel := context.WithTimeout(root, 10*time.Second)
+		defer cancel()
+
+		err := c.CloseContext(ctx)
+		if err == nil {
+			t.Fatal("CloseContext with a context derived from the cancelled root " +
+				"returned nil; it cannot have waited for anything, so this test no " +
+				"longer distinguishes the two derivations")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("error does not wrap context.Canceled: %v", err)
+		}
+		if backup.keyCount() != 0 {
+			t.Log("note: the transfer landed anyway (scheduling); the error above is " +
+				"still the signal that shutdown stopped observing it")
+		}
+	})
+}
+
+// ── Refused Start (#84) ───────────────────────────────────────────────────────
+
+// TestStart_RefusalIsDetectable pins the contract main.go now depends on: a
+// coordinator that has been stopped refuses Start with an error, so the check
+// added at the Start call site can actually fire.
+//
+// This is deliberately a test of the boundary and not of main() itself.  The
+// consequence of a refused Start in the daemon is os.Exit(1), which is not
+// observable from a test in this package without restructuring main into an
+// injectable run() returning an error — a change well beyond the scope of these
+// commits and one that would touch every path in a 300-line function nothing
+// else currently covers.  Rather than force it, this asserts the half that is
+// real: that the error main keys off is produced, is non-nil, and identifies
+// itself via errors.Is so the call site cannot be fooled by a formatting change.
+// The os.Exit itself is reviewed, not tested, and is called out as such in the
+// PR.
+func TestStart_RefusalIsDetectable(t *testing.T) {
+	c := coordinator.New(site.New("primary", types.SiteRolePrimary, newTestMemClient(nil)))
+	c.Stop() // single-use lifecycle: this is now terminal
+
+	err := c.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start on a stopped coordinator returned nil; the daemon would run " +
+			"with no replication worker and no health poller, reporting healthy (#84)")
+	}
+	if !errors.Is(err, coordinator.ErrStopped) {
+		t.Errorf("Start error does not wrap ErrStopped: %v", err)
+	}
+}
+
+// TestMustConfigure_PassesOnNil is a guard on the helper's happy path, which is
+// the one every shipped boot takes.  The failure path calls os.Exit and is not
+// testable in-process; see TestStart_RefusalIsDetectable for why that is being
+// stated rather than worked around.
+func TestMustConfigure_PassesOnNil(t *testing.T) {
+	mustConfigure("nothing wrong", nil) // must not exit
+}

--- a/cmd/globalfs/main.go
+++ b/cmd/globalfs/main.go
@@ -31,6 +31,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -303,6 +304,12 @@ func buildObjectGetCmd() *cobra.Command {
 type objectPutResult struct {
 	Key   string `json:"key"`
 	Bytes int    `json:"bytes"`
+	// ReplicationPending is true when the object is stored and readable but
+	// replication to one or more secondaries was not queued (#130).  Omitted on a
+	// fully replicated write so existing --json consumers see an unchanged shape.
+	ReplicationPending bool `json:"replication_pending,omitempty"`
+	// Detail carries the coordinator's explanation when ReplicationPending is set.
+	Detail string `json:"detail,omitempty"`
 }
 
 func buildObjectPutCmd() *cobra.Command {
@@ -332,14 +339,41 @@ func buildObjectPutCmd() *cobra.Command {
 			}
 
 			c := newClient()
-			if err := c.PutObject(context.Background(), key, data); err != nil {
+			// ErrReplicationPending is a committed write, so it is reported as a
+			// success with a caveat rather than as a failure (#130).  Printing
+			// "error" here for durable bytes is the concrete harm the issue names:
+			// an operator, or a script keying off the exit status, retries an upload
+			// that already landed.
+			//
+			// Exit status stays 0 for the same reason.  A non-zero exit is the only
+			// signal `set -e` and CI runners read, and it would make every one of
+			// them treat a stored object as a failed step.  Replication being
+			// behind is a condition of the deployment, not of this command — the
+			// coordinator retries it — and it is already visible in the text, in
+			// --json, and on the coordinator's own metrics.  If a caller does want
+			// to gate on it, --json now carries replication_pending.
+			result := objectPutResult{Key: key, Bytes: len(data)}
+			switch err := c.PutObject(context.Background(), key, data); {
+			case errors.Is(err, client.ErrReplicationPending):
+				result.ReplicationPending = true
+				result.Detail = err.Error()
+			case err != nil:
 				return err
 			}
 
 			if jsonOutput {
-				return printJSON(cmd.OutOrStdout(), objectPutResult{Key: key, Bytes: len(data)})
+				return printJSON(cmd.OutOrStdout(), result)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "stored %q (%d bytes)\n", key, len(data))
+			if result.ReplicationPending {
+				// Stderr, so the caveat is visible without contaminating stdout for
+				// anyone parsing the success line.
+				// Write error ignored as everywhere else in this file: a failed
+				// write to stderr must not turn a stored object into a failure.
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: replication is not yet queued for %q; the object is stored and readable, do not re-upload it (%s)\n",
+					key, result.Detail)
+			}
 			return nil
 		},
 	}

--- a/cmd/globalfs/main_test.go
+++ b/cmd/globalfs/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/scttfrdmn/globalfs/pkg/client"
@@ -1038,5 +1039,151 @@ func TestFormatUptime(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("formatUptime(%v): got %q, want %q", tc.secs, got, tc.want)
 		}
+	}
+}
+
+// ─── object put: partial replication (#130) ───────────────────────────────────
+
+// runCmdSplit is runCmd with stdout and stderr captured separately, which the
+// tests below need: the point of the warning is that it does *not* land on
+// stdout, and a merged buffer cannot show that.  Stdin is a fixed payload so
+// `--input -` never reaches the real os.Stdin.
+func runCmdSplit(t *testing.T, addr string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	root := buildRoot()
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetIn(strings.NewReader("payload"))
+	root.SetArgs(append([]string{"--coordinator-addr", addr}, args...))
+	err = root.Execute()
+	return out.String(), errBuf.String(), err
+}
+
+// putCounter counts PUTs seen by a test server.  Guarded because the handler runs
+// on the server's goroutine and the assertion on the test's.
+type putCounter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (p *putCounter) inc() {
+	p.mu.Lock()
+	p.n++
+	p.mu.Unlock()
+}
+
+func (p *putCounter) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.n
+}
+
+// putPartialServer answers every PUT with the coordinator's 202 for a stored but
+// un-replicated write, and counts requests so a retry is visible.
+func putPartialServer(t *testing.T, requests *putCounter) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		requests.inc()
+		w.Header().Set("X-GlobalFS-Replication", "pending")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = io.WriteString(w, `{"key":"`+r.PathValue("key")+`",`+
+			`"status":"stored; replication incomplete",`+
+			`"detail":"stored on primaries but replication not queued for [backup]"}`)
+	})
+	return newTestServer(t, mux)
+}
+
+// TestObjectPut_ReplicationPendingIsNotAFailure is the end of the #130 round
+// trip: a 202 from the coordinator must reach the operator as a stored object
+// with a caveat, not as an error, and must exit 0 so `set -e` scripts do not
+// treat a committed write as a failed step.
+func TestObjectPut_ReplicationPendingIsNotAFailure(t *testing.T) {
+	var requests putCounter
+	addr := putPartialServer(t, &requests)
+
+	stdout, stderr, err := runCmdSplit(t, addr, "object", "put", "uploads/x", "--input", "-")
+	if err != nil {
+		t.Fatalf("object put reported a committed write as a failure: %v", err)
+	}
+	if !strings.Contains(stdout, "stored") {
+		t.Errorf("stdout does not report the object as stored: %q", stdout)
+	}
+	if !strings.Contains(stderr, "replication") {
+		t.Errorf("stderr does not mention the pending replication: %q", stderr)
+	}
+	if !strings.Contains(stderr, "do not re-upload") {
+		t.Errorf("stderr does not tell the operator the write is committed: %q", stderr)
+	}
+	// The caveat belongs on stderr; stdout stays the success line so anything
+	// parsing it is unaffected.
+	if strings.Contains(stdout, "warning") {
+		t.Errorf("the warning contaminated stdout: %q", stdout)
+	}
+	if got := requests.count(); got != 1 {
+		t.Errorf("server saw %d PUTs, want 1: a committed write must not be retried", got)
+	}
+}
+
+// TestObjectPut_ReplicationPendingJSON pins the machine-readable form, and that
+// the field is absent on an ordinary success so existing --json consumers are
+// unaffected.
+func TestObjectPut_ReplicationPendingJSON(t *testing.T) {
+	var requests putCounter
+	addr := putPartialServer(t, &requests)
+
+	stdout, _, err := runCmdSplit(t, addr, "object", "put", "k", "--input", "-", "--json")
+	if err != nil {
+		t.Fatalf("object put --json: %v", err)
+	}
+	var result objectPutResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal %q: %v", stdout, err)
+	}
+	if !result.ReplicationPending {
+		t.Error("replication_pending is false for a 202")
+	}
+	if result.Detail == "" {
+		t.Error("detail is empty for a 202")
+	}
+	if result.Key != "k" {
+		t.Errorf("key = %q, want k", result.Key)
+	}
+
+	// An ordinary 201 must not grow the new fields.
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	okAddr := newTestServer(t, mux)
+
+	stdout, _, err = runCmdSplit(t, okAddr, "object", "put", "k", "--input", "-", "--json")
+	if err != nil {
+		t.Fatalf("object put --json (201): %v", err)
+	}
+	if strings.Contains(stdout, "replication_pending") {
+		t.Errorf("a fully replicated write emitted replication_pending: %q", stdout)
+	}
+}
+
+// TestObjectPut_RealFailureStillFails is the other half: the new success path
+// must not swallow a genuine write failure.
+func TestObjectPut_RealFailureStillFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, `{"error":"disk full"}`)
+	})
+	addr := newTestServer(t, mux)
+
+	stdout, _, err := runCmdSplit(t, addr, "object", "put", "k", "--input", "-")
+	if err == nil {
+		t.Fatal("object put returned nil for a 502: a failed write would be reported as stored")
+	}
+	if strings.Contains(stdout, "stored") {
+		t.Errorf("a failed write printed the success line: %q", stdout)
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -127,6 +127,46 @@ const apiKeyHeader = "X-GlobalFS-API-Key"
 // likely cause and the Location is the thing that identifies it.
 var ErrUnexpectedRedirect = errors.New("coordinator returned an unexpected redirect")
 
+// ErrReplicationPending reports that a PutObject write was committed but
+// replication to one or more secondaries could not be queued.
+//
+// The write succeeded.  The bytes are durable on every primary and the object is
+// readable immediately; only the asynchronous copies to the named secondaries
+// were not scheduled, and the coordinator answered 202 rather than 201 to say so
+// (#130).  A caller must not retry the write on this error: the retry would be a
+// second full upload of data that is already stored.
+//
+// It is returned as an error rather than swallowed into a nil precisely because
+// the write is not wholly complete.  A nil would make the client report full
+// durability the coordinator did not claim — the "success while something is
+// wrong" shape that #130 and its neighbours are about, just inverted.  So the
+// contract is: non-nil, but committed.  Test for it and continue:
+//
+//	err := c.PutObject(ctx, key, data)
+//	switch {
+//	case errors.Is(err, client.ErrReplicationPending):
+//	    // stored; log it, do not retry
+//	case err != nil:
+//	    return err
+//	}
+//
+// A sentinel is used rather than a distinct exported type, or a changed
+// PutObject signature, for three reasons.  It matches how the coordinator
+// already communicates this condition internally (ErrReplicationNotQueued), so
+// the same shape survives the whole round trip.  errors.Is answers the only
+// question a caller has to ask, with no string matching and no type assertion,
+// and it stays correct if the error is later wrapped further up.  And it does not
+// break the signature, so every existing caller that treats a non-nil error as
+// "did not fully succeed" remains *safe* by default — conservative, never
+// silently wrong — while a caller who cares can opt into the distinction.
+//
+// The wrapped message carries the coordinator's detail string, which names the
+// destinations that got no job.  As on the server side, those names are not
+// broken out into fields: obtaining them would mean parsing another package's
+// formatted output, which is a silent breakage waiting for that format to
+// change.
+var ErrReplicationPending = errors.New("object stored but replication was not queued")
+
 // ErrInvalidKey reports that an object key was rejected locally, before any
 // request was sent.
 //
@@ -409,7 +449,13 @@ func (c *Client) GetObject(ctx context.Context, key string) ([]byte, error) {
 	return data, nil
 }
 
-// PutObject stores data under key. It returns nil on success.
+// PutObject stores data under key. It returns nil when the object is stored and
+// fully replicated (the coordinator's 201).
+//
+// It returns an error wrapping [ErrReplicationPending] when the object is stored
+// but replication could not be queued (the coordinator's 202).  That case is a
+// committed write and must not be retried; see [ErrReplicationPending].  Any
+// other non-2xx is an *[APIError] and the write did not happen.
 //
 // An invalid key is rejected locally; see GetObject and [ErrInvalidKey].
 func (c *Client) PutObject(ctx context.Context, key string, data []byte) error {
@@ -421,7 +467,47 @@ func (c *Client) PutObject(ctx context.Context, key string, data []byte) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	// Branch here rather than teaching checkStatus a set of acceptable codes.
+	// checkStatus's job is "this code is wrong, here is why", and the two 2xx
+	// codes do not mean the same thing to the caller — a multi-status form of
+	// checkStatus would collapse them back into one and lose the distinction this
+	// method exists to report.  ListObjects treats 207 the same way, for the same
+	// reason (see its comment); this keeps the two consistent.
+	if resp.StatusCode == http.StatusAccepted {
+		return fmt.Errorf("put object %q: %w: %s", key, ErrReplicationPending, putPartialDetail(resp))
+	}
 	return checkStatus(resp, http.StatusCreated)
+}
+
+// objectPutPartialResponse mirrors the coordinator's 202 body for a stored write
+// whose replication was not queued.  It is deliberately not an error envelope on
+// the wire, so it cannot be read out by checkStatus.
+type objectPutPartialResponse struct {
+	Key    string `json:"key"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// putPartialDetail extracts the coordinator's explanation from a 202 body,
+// falling back to a fixed string when the body is absent or unparseable.
+//
+// The fallback matters: the caller's decision is driven by ErrReplicationPending,
+// which is already established by the status code, so a body that cannot be read
+// must not be allowed to turn a committed write into a different outcome.  An
+// older coordinator, or a proxy that strips the body, still yields the correct
+// sentinel with a vaguer message.
+func putPartialDetail(resp *http.Response) string {
+	var partial objectPutPartialResponse
+	if err := json.NewDecoder(resp.Body).Decode(&partial); err == nil {
+		if partial.Detail != "" {
+			return partial.Detail
+		}
+		if partial.Status != "" {
+			return partial.Status
+		}
+	}
+	return "coordinator reported the write as stored but not fully replicated"
 }
 
 // HeadObject returns metadata for the object at key without fetching its

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -104,6 +105,80 @@ func (e *APIError) Error() string {
 // apiKeyHeader is the HTTP request header used for authentication.
 const apiKeyHeader = "X-GlobalFS-API-Key"
 
+// ErrUnexpectedRedirect reports that the coordinator answered with a redirect,
+// which this client refuses to follow.
+//
+// The GlobalFS API has no legitimate redirects, so one is either a
+// misconfiguration — a reverse proxy in front of the coordinator rewriting or
+// canonicalising the path — or an attempt to steer a request somewhere else.
+// Both are better reported to the caller than transparently obeyed.
+//
+// Following one is not neutral.  Go's http.Client replays the method *and* the
+// X-GlobalFS-API-Key header on a 307, so a redirect turns into a second,
+// differently-targeted, still-authenticated request.  That is the mechanism that
+// made #73 exploitable: against a server that path-cleaned ".." into a 307,
+// DeleteObject(ctx, "../sites/primary") followed the redirect and deregistered a
+// site, returning nil.  #73 closed that on the server, so this is hardening for
+// a pre-#73 or misconfigured coordinator rather than a live hole against a
+// current one — but the credential is carried by the client, and the client is
+// where the decision to hand it to a new target is made.
+//
+// The error names the redirect target, since a proxy misconfiguration is the
+// likely cause and the Location is the thing that identifies it.
+var ErrUnexpectedRedirect = errors.New("coordinator returned an unexpected redirect")
+
+// ErrInvalidKey reports that an object key was rejected locally, before any
+// request was sent.
+//
+// The rule matches the coordinator's own validateObjectKey — no ".." path
+// components and no null bytes — deliberately: a client should not send a
+// request it already knows the server must refuse, and a local failure is
+// immediate and unambiguous where a 400 from a coordinator the caller may not
+// control is neither.  Against a server that does *not* refuse it, this is the
+// check that stops the request being made at all.
+var ErrInvalidKey = errors.New("invalid object key")
+
+// validateKey rejects object keys that could escape their intended path.
+//
+// Same rule, and same reasoning, as cmd/coordinator's validateObjectKey: a ".."
+// component can be path-cleaned by an intermediary or a server's mux into a
+// different route, and a null byte truncates the key for anything downstream
+// written in C.  Both are checked on the literal key the caller passed, which is
+// the only spelling this client has — it does not percent-encode the key when
+// building the URL, so nothing here can hide behind an escape.
+func validateKey(key string) error {
+	if strings.Contains(key, "\x00") {
+		return fmt.Errorf("%w %q: contains null byte", ErrInvalidKey, key)
+	}
+	for _, part := range strings.Split(key, "/") {
+		if part == ".." {
+			return fmt.Errorf("%w %q: contains path traversal component", ErrInvalidKey, key)
+		}
+	}
+	return nil
+}
+
+// refuseRedirects is the http.Client CheckRedirect policy: never follow, and
+// report where the redirect pointed.
+//
+// Returning an error rather than http.ErrUseLastResponse is the choice that makes
+// the condition impossible to miss.  ErrUseLastResponse would surface the 307 as
+// an ordinary *APIError, which every call site would then have to recognise as a
+// redirect on its own; an error here means no follow-up request is ever built —
+// CheckRedirect runs before it is sent — and so the API key is never put on the
+// wire a second time.
+//
+// via[0] is the original request, which is the useful thing to name alongside the
+// target: "this is where you asked to go, this is where you were sent".
+func refuseRedirects(req *http.Request, via []*http.Request) error {
+	from := ""
+	if len(via) > 0 && via[0].URL != nil {
+		from = via[0].URL.String()
+	}
+	return fmt.Errorf("%w: %s -> %s (not followed; the API key is not replayed)",
+		ErrUnexpectedRedirect, from, req.URL)
+}
+
 // ── Client ────────────────────────────────────────────────────────────────────
 
 // Client communicates with a GlobalFS coordinator over HTTP.
@@ -117,6 +192,13 @@ type Client struct {
 type Option func(*Client)
 
 // WithHTTPClient replaces the default *http.Client.
+//
+// The supplied client is not used directly: New takes a shallow copy and, if the
+// copy has no CheckRedirect of its own, installs the no-redirect policy on it.
+// The copy shares the Transport, so connection pooling and any custom
+// RoundTripper are preserved, and the caller's client is left unmodified.  A
+// caller that sets CheckRedirect keeps it — including one that deliberately
+// follows redirects, which is then their decision and not a default.
 func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
 }
@@ -141,6 +223,11 @@ func (c *Client) setAPIKey(req *http.Request) {
 
 // New creates a Client that speaks to the coordinator at coordinatorAddr.
 // coordinatorAddr should include scheme and host, e.g. "http://localhost:8090".
+//
+// The returned Client does not follow HTTP redirects: a 3xx with a Location is
+// reported as an error wrapping [ErrUnexpectedRedirect] rather than obeyed, so
+// the API key is never replayed to a target the coordinator (or an intermediary)
+// chose.  See ErrUnexpectedRedirect for why that matters (#132).
 func New(coordinatorAddr string, opts ...Option) *Client {
 	c := &Client{
 		baseURL:    strings.TrimRight(coordinatorAddr, "/"),
@@ -148,6 +235,19 @@ func New(coordinatorAddr string, opts ...Option) *Client {
 	}
 	for _, o := range opts {
 		o(c)
+	}
+	// Applied after the options, so a client supplied by WithHTTPClient is covered
+	// too — that is the path a caller most plausibly uses to install a custom
+	// Transport, and it would otherwise silently opt out of the policy.  Copying
+	// rather than mutating keeps the caller's own *http.Client untouched: it may be
+	// shared with unrelated code that does want redirects.
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	if c.httpClient.CheckRedirect == nil {
+		hc := *c.httpClient
+		hc.CheckRedirect = refuseRedirects
+		c.httpClient = &hc
 	}
 	return c
 }
@@ -269,7 +369,13 @@ func (c *Client) Status(ctx context.Context) (StatusResponse, error) {
 // mid-body, or a body shorter than the advertised Content-Length, is reported as
 // an error and the partial bytes are discarded (#74).  Callers can therefore
 // treat a nil error as meaning the returned slice is the whole object.
+//
+// A key containing a ".." component or a null byte is rejected locally, without
+// any request being sent; the returned error wraps [ErrInvalidKey] (#132).
 func (c *Client) GetObject(ctx context.Context, key string) ([]byte, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
 	resp, err := c.doGet(ctx, "/api/v1/objects/"+key)
 	if err != nil {
 		return nil, err
@@ -304,7 +410,12 @@ func (c *Client) GetObject(ctx context.Context, key string) ([]byte, error) {
 }
 
 // PutObject stores data under key. It returns nil on success.
+//
+// An invalid key is rejected locally; see GetObject and [ErrInvalidKey].
 func (c *Client) PutObject(ctx context.Context, key string, data []byte) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
 	resp, err := c.doPut(ctx, "/api/v1/objects/"+key, data)
 	if err != nil {
 		return err
@@ -315,7 +426,12 @@ func (c *Client) PutObject(ctx context.Context, key string, data []byte) error {
 
 // HeadObject returns metadata for the object at key without fetching its
 // content. The returned ObjectInfo is populated from HTTP response headers.
+//
+// An invalid key is rejected locally; see GetObject and [ErrInvalidKey].
 func (c *Client) HeadObject(ctx context.Context, key string) (*ObjectInfo, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
 	resp, err := c.doHead(ctx, "/api/v1/objects/"+key)
 	if err != nil {
 		return nil, err
@@ -342,7 +458,14 @@ func (c *Client) HeadObject(ctx context.Context, key string) (*ObjectInfo, error
 }
 
 // DeleteObject removes the object at key. It returns nil on success.
+//
+// An invalid key is rejected locally, without a request being sent — this is the
+// method the #73 exploit used, as DeleteObject(ctx, "../sites/primary"), and the
+// destructive one of the four.  See [ErrInvalidKey].
 func (c *Client) DeleteObject(ctx context.Context, key string) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
 	resp, err := c.doDelete(ctx, "/api/v1/objects/"+key)
 	if err != nil {
 		return err

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -971,3 +971,320 @@ func TestWithAPIKey_SetsHeaderOnAllMethods(t *testing.T) {
 		t.Errorf("expected 4 requests, got %d", len(gotKeys))
 	}
 }
+
+// ── Redirects are not followed (#132) ─────────────────────────────────────────
+
+// TestRedirect_NotFollowed is the core #132 assertion: a coordinator that answers
+// with a redirect gets an error, not a second request.
+//
+// The redirect target here is the site route, which is the #73 shape exactly: a
+// server that path-cleans "../sites/primary" answers 307 with
+// Location=/api/v1/sites/primary, and Go's default policy replays both the method
+// and X-GlobalFS-API-Key, turning an object DELETE into a site deregistration
+// that returns nil.  #73 closed that on the server, so this is the client half —
+// what keeps the same exploit from working against a pre-#73 or misconfigured
+// coordinator.
+//
+// The assertion is a request count of one.  A status-code assertion would not
+// distinguish "refused to follow" from "followed, and the target answered".
+func TestRedirect_NotFollowed(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if strings.HasPrefix(r.URL.Path, "/api/v1/objects/") {
+			http.Redirect(w, r, "/api/v1/sites/primary", http.StatusTemporaryRedirect)
+			return
+		}
+		// The redirect target: succeeds if it is ever reached, so a followed
+		// redirect shows up as a nil error rather than an incidental failure.
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL)
+	err := c.DeleteObject(context.Background(), "data/x")
+	if err == nil {
+		t.Fatal("DeleteObject returned nil against a 307 — the redirect was followed and " +
+			"the deregistration it pointed at reported success (#132)")
+	}
+	if !errors.Is(err, client.ErrUnexpectedRedirect) {
+		t.Errorf("error does not wrap ErrUnexpectedRedirect: %v", err)
+	}
+	// The Location is named, because a proxy in front of the coordinator is the
+	// likely cause and the target is what identifies it.
+	if !strings.Contains(err.Error(), "/api/v1/sites/primary") {
+		t.Errorf("error does not name the redirect target, which is what diagnoses a "+
+			"misconfigured proxy: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 1 {
+		t.Fatalf("server saw %d requests, want 1: %v", len(paths), paths)
+	}
+	if paths[0] != "/api/v1/objects/data/x" {
+		t.Errorf("first request path = %q, want the object path", paths[0])
+	}
+}
+
+// TestRedirect_APIKeyNotReplayed is the credential half of #132.  Go strips
+// sensitive headers when a redirect crosses to a different host, but not on a
+// same-host redirect, and it gives a custom Authorization-style header like
+// X-GlobalFS-API-Key no special treatment at all — so pre-fix the key was handed
+// to whatever Location the server named.
+//
+// Both assertions matter: one request total, and the key present on that one.  A
+// client that stopped sending the key at all would also satisfy "never appears on
+// a second request".
+func TestRedirect_APIKeyNotReplayed(t *testing.T) {
+	const key = "secret-key"
+	var mu sync.Mutex
+	var keysSeen []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		keysSeen = append(keysSeen, r.Header.Get("X-GlobalFS-API-Key"))
+		mu.Unlock()
+		http.Redirect(w, r, "/api/v1/sites/primary", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, client.WithAPIKey(key))
+	if _, err := c.GetObject(context.Background(), "data/x"); err == nil {
+		t.Fatal("GetObject returned nil against a 307")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(keysSeen) != 1 {
+		t.Fatalf("the API key was sent on %d requests, want 1 — a redirect must not "+
+			"replay the credential (#132): %v", len(keysSeen), keysSeen)
+	}
+	if keysSeen[0] != key {
+		t.Errorf("first request carried key %q, want %q; the test would pass vacuously "+
+			"if the key were never sent at all", keysSeen[0], key)
+	}
+}
+
+// TestRedirect_AllMethodsRefuse covers every method, not only the one #73 used.
+// The policy lives on the http.Client, so this is really a guard against a future
+// doX helper being given its own client or its own policy.
+func TestRedirect_AllMethodsRefuse(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		http.Redirect(w, r, "/api/v1/sites/primary", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL)
+	ctx := context.Background()
+
+	calls := map[string]func() error{
+		"GetObject":    func() error { _, err := c.GetObject(ctx, "k"); return err },
+		"PutObject":    func() error { return c.PutObject(ctx, "k", []byte("v")) },
+		"DeleteObject": func() error { return c.DeleteObject(ctx, "k") },
+		"HeadObject":   func() error { _, err := c.HeadObject(ctx, "k"); return err },
+		"ListObjects":  func() error { _, err := c.ListObjects(ctx, "", 0); return err },
+		"ListSites":    func() error { _, err := c.ListSites(ctx); return err },
+		"AddSite":      func() error { _, err := c.AddSite(ctx, client.AddSiteRequest{Name: "s"}); return err },
+		"RemoveSite":   func() error { return c.RemoveSite(ctx, "s") },
+		"Replicate":    func() error { _, err := c.Replicate(ctx, client.ReplicateRequest{Key: "k"}); return err },
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil {
+				t.Fatalf("%s returned nil against a 307", name)
+			}
+			if !errors.Is(err, client.ErrUnexpectedRedirect) {
+				t.Errorf("%s: error does not wrap ErrUnexpectedRedirect: %v", name, err)
+			}
+		})
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != len(calls) {
+		t.Errorf("server saw %d requests for %d calls; a followed redirect makes more "+
+			"than one request per call", requests, len(calls))
+	}
+}
+
+// TestRedirect_PolicyAppliesToWithHTTPClient covers the path a caller most
+// plausibly uses to install a custom Transport.  A client supplied through
+// WithHTTPClient must not silently opt out of the policy — that would make the
+// hardening depend on which constructor options happened to be used.
+func TestRedirect_PolicyAppliesToWithHTTPClient(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		http.Redirect(w, r, "/api/v1/sites/primary", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	supplied := &http.Client{Timeout: 5 * time.Second}
+	c := client.New(srv.URL, client.WithHTTPClient(supplied))
+
+	if err := c.DeleteObject(context.Background(), "k"); !errors.Is(err, client.ErrUnexpectedRedirect) {
+		t.Errorf("WithHTTPClient bypassed the redirect policy: %v", err)
+	}
+	// The caller's own client must be left alone: it may be shared with code that
+	// does want redirects.
+	if supplied.CheckRedirect != nil {
+		t.Error("New mutated the caller's *http.Client instead of copying it")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Errorf("server saw %d requests, want 1", requests)
+	}
+}
+
+// TestRedirect_CallerCheckRedirectIsRespected is the escape hatch.  A caller who
+// sets CheckRedirect has made a decision, and New must not override it — the
+// no-redirect policy is a default, not a prohibition.
+func TestRedirect_CallerCheckRedirectIsRespected(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		n := requests
+		mu.Unlock()
+		if n == 1 {
+			http.Redirect(w, r, "/api/v1/objects/elsewhere", http.StatusTemporaryRedirect)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	follow := &http.Client{
+		Timeout:       5 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
+	}
+	c := client.New(srv.URL, client.WithHTTPClient(follow))
+
+	if err := c.DeleteObject(context.Background(), "k"); err != nil {
+		t.Errorf("a caller-supplied CheckRedirect was overridden: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 2 {
+		t.Errorf("server saw %d requests, want 2 (the redirect should have been followed)", requests)
+	}
+}
+
+// ── Client-side key validation (#132) ─────────────────────────────────────────
+
+// TestObjectKey_TraversalRejectedLocally asserts that a key the server must
+// refuse is never sent.  The first case is the #73 exploit's own argument:
+// DeleteObject(ctx, "../sites/primary").
+//
+// A request count of zero is the assertion, not a status code.  Making the
+// request and getting a 400 back would produce an error too, and against a
+// coordinator that does *not* refuse it would produce a site deregistration.
+func TestObjectKey_TraversalRejectedLocally(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		// Stands in for a pre-#73 coordinator: obeys whatever it is asked.
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL)
+	ctx := context.Background()
+
+	keys := []string{
+		"../sites/primary",
+		"a/../../sites/primary",
+		"data/..",
+		"..",
+		"data/\x00/x",
+		"\x00",
+	}
+	for _, key := range keys {
+		t.Run(strconv.Quote(key), func(t *testing.T) {
+			for name, call := range map[string]func() error{
+				"DeleteObject": func() error { return c.DeleteObject(ctx, key) },
+				"GetObject":    func() error { _, err := c.GetObject(ctx, key); return err },
+				"PutObject":    func() error { return c.PutObject(ctx, key, []byte("v")) },
+				"HeadObject":   func() error { _, err := c.HeadObject(ctx, key); return err },
+			} {
+				err := call()
+				if err == nil {
+					t.Errorf("%s(%q) returned nil", name, key)
+					continue
+				}
+				if !errors.Is(err, client.ErrInvalidKey) {
+					t.Errorf("%s(%q): error does not wrap ErrInvalidKey: %v", name, key, err)
+				}
+			}
+		})
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 0 {
+		t.Errorf("the client sent %d request(s) for keys it knows the server must refuse; "+
+			"against a pre-#73 coordinator each one is the traversal (#132)", requests)
+	}
+}
+
+// TestObjectKey_LegitimateKeysStillWork is the regression guard on the check
+// above.  ".." as a substring rather than a whole path component is a legal S3
+// key, and so is a leading dot; rejecting those would break real callers to fix a
+// traversal they are not.
+func TestObjectKey_LegitimateKeysStillWork(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL)
+	keys := []string{
+		"data/genome.bam",
+		"data/..hidden",
+		"data/file..bak",
+		"data/...",
+		"a..b/c",
+		".hidden",
+	}
+	for _, key := range keys {
+		if err := c.DeleteObject(context.Background(), key); err != nil {
+			t.Errorf("DeleteObject(%q) rejected a legal S3 key: %v", key, err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != len(keys) {
+		t.Errorf("server saw %d requests for %d legal keys: %v", len(paths), len(keys), paths)
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1288,3 +1288,120 @@ func TestObjectKey_LegitimateKeysStillWork(t *testing.T) {
 		t.Errorf("server saw %d requests for %d legal keys: %v", len(paths), len(keys), paths)
 	}
 }
+
+// ── PutObject partial success (#130) ──────────────────────────────────────────
+
+// TestPutObject_202IsCommittedButPending pins the client half of #130: the
+// coordinator's 202 must arrive as something errors.Is-testable, and the caller
+// must be able to tell it apart from a real failure without reading the message.
+func TestPutObject_202IsCommittedButPending(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-GlobalFS-Replication", "pending")
+		writeJSON(w, http.StatusAccepted, map[string]string{
+			"key":    r.PathValue("key"),
+			"status": "stored; replication incomplete",
+			"detail": `coordinator: Put "uploads/data.bin": stored on primaries but replication not queued for [backup]`,
+		})
+	})
+	c := newServer(t, mux)
+
+	err := c.PutObject(context.Background(), "uploads/data.bin", []byte("payload"))
+	if err == nil {
+		t.Fatal("PutObject returned nil for a 202: a partially replicated write must not be reported as fully stored")
+	}
+	if !errors.Is(err, client.ErrReplicationPending) {
+		t.Fatalf("PutObject error does not wrap ErrReplicationPending: %#v (%v)", err, err)
+	}
+	// The whole point of the sentinel is that no *APIError leaks out: a caller
+	// switching on *APIError would treat this as a failed request.
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) {
+		t.Errorf("a 202 produced an *APIError (status %d): a committed write must not look like a failed request",
+			apiErr.StatusCode)
+	}
+	// The detail is carried through so an operator can see which site is behind.
+	if !strings.Contains(err.Error(), "backup") {
+		t.Errorf("error text lost the coordinator's detail (should name the un-queued site): %v", err)
+	}
+}
+
+// TestPutObject_PendingAndFailureAreDistinguishable is the assertion the
+// coordinator says matters: a partial success and a genuine failure must be told
+// apart by errors.Is alone, with no substring matching on either.
+func TestPutObject_PendingAndFailureAreDistinguishable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.PathValue("key") {
+		case "pending":
+			writeJSON(w, http.StatusAccepted, map[string]string{"detail": "not queued for [backup]"})
+		default:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "disk full"})
+		}
+	})
+	c := newServer(t, mux)
+
+	pendingErr := c.PutObject(context.Background(), "pending", []byte("v"))
+	failErr := c.PutObject(context.Background(), "broken", []byte("v"))
+
+	if !errors.Is(pendingErr, client.ErrReplicationPending) {
+		t.Errorf("202 did not wrap ErrReplicationPending: %v", pendingErr)
+	}
+	if errors.Is(failErr, client.ErrReplicationPending) {
+		t.Errorf("502 wrapped ErrReplicationPending: a failed write would be treated as committed and never retried: %v", failErr)
+	}
+
+	// And the 502 must still be a plain failure with its status code intact.
+	var apiErr *client.APIError
+	if !errors.As(failErr, &apiErr) {
+		t.Fatalf("502 did not produce an *APIError, got %T: %v", failErr, failErr)
+	}
+	if apiErr.StatusCode != http.StatusBadGateway {
+		t.Errorf("*APIError carries status %d, want 502", apiErr.StatusCode)
+	}
+}
+
+// TestPutObject_202WithUnreadableBodyStillPending checks that the sentinel is
+// driven by the status code, not by the body: a coordinator or proxy that omits
+// or mangles the JSON must not turn a committed write into a different outcome.
+func TestPutObject_202WithUnreadableBodyStillPending(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"empty body", ""},
+		{"not json", "replication queue full"},
+		{"json without detail", `{"key":"k"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(w, tc.body)
+			})
+			c := newServer(t, mux)
+
+			err := c.PutObject(context.Background(), "k", []byte("v"))
+			if !errors.Is(err, client.ErrReplicationPending) {
+				t.Fatalf("202 with %s did not wrap ErrReplicationPending: %v", tc.name, err)
+			}
+			if err.Error() == "" {
+				t.Error("error message is empty")
+			}
+		})
+	}
+}
+
+// TestPutObject_201IsStillNil guards the other direction: the branch added for
+// 202 must not change the fully-successful case.
+func TestPutObject_201IsStillNil(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/objects/{key...}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	c := newServer(t, mux)
+
+	if err := c.PutObject(context.Background(), "k", []byte("v")); err != nil {
+		t.Fatalf("a 201 must be a nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
Three follow-ups filed after the v0.2.2 review, a fourth commit closing a gap
found in review of the first, and a fifth wiring up the daemon side of the
lifecycle work. The three issues exist because v0.2.2 added coordinator-level API
that nothing called yet, so most of this is wiring — but each had a detail worth
getting right, and those are what the notes below are about.

**The #130 round trip is now verified end to end.** That is a separate claim from
"the coordinator returns 202", and conflating the two is what the fourth commit
fixes — see below.

> ### ⚠ Depends on #136 landing first
>
> `origin/fix/v0.2.3-lifecycle` is merged into this branch (merge commit, no
> conflicts — the two touch disjoint files). The fifth commit calls
> `CloseContext` and checks errors from `Start` and four setters, none of which
> exist on `main` today, so **this branch will not build against `main` until #136
> is in.** Merge #136 first, or merge this and #136 together.
>
> If #136 is reworked before it lands, the fifth commit here is the part to
> re-check: it is written against that branch's exact signatures.

Refs #130, #131, #132, #83, #84.

## #130 — a stored write whose replication was not queued is 202, not 502

`objectPutHandler` mapped every `Coordinator.Put` error to 502. Since #79 one of
them wraps `ErrReplicationNotQueued`, documented at its declaration as a *partial
success*: bytes durable on every primary, object readable immediately, only the
named secondaries missing a job. So a committed write was reported as a gateway
failure — callers retry a write that already landed, and 5xx alerting fires on a
queue backlog. The handler now branches on the sentinel and answers 202; a
genuine primary-write failure is untouched at 502, which is the half that keeps
this from turning every failed write into a reported success.

**Decision on open question 1 — `writeError` is not the right helper, and is not
used.** It emits `{"error": ...}`, and a client keying off that field to decide
whether a request failed would read this success as a failure — the same defect
the issue is about, moved from the status code into the body. The 202 carries a
distinct `objectPutPartialResponse` of `key`/`status`/`detail` instead.

`detail` is the coordinator's message verbatim, which already names the
destinations that got no job. I did **not** break them out into a structured
field: the only way to obtain them here is to parse another package's formatted
error string, and a parser of a `%v` format is a silent breakage waiting for the
next edit to that format. Structured destinations need a typed error from
`internal/coordinator`, which is another agent's file this round. Flagging it
rather than doing it.

**Decision on open question 2 — yes, a header.** `X-GlobalFS-Replication:
pending`, following the `X-GlobalFS-Partial` precedent on the 207 list path
(#33/#104). A 202 alone is ambiguous — `replicateHandler` returns one for an
ordinary success — and a proxy, an access log, or a metrics pipeline can act on a
header where it has no body to parse.

Both decisions are pinned by assertions, not just described in prose:
implementing the issue's literal suggestion, `writeError(w,
http.StatusAccepted, err.Error())`, fails the test on the empty header, on the
body carrying an `"error"` field, and on all three of key/status/detail being
absent.

### #130, second half: the 202 had to reach the caller (4th commit)

Fixing the status code did not fix the behaviour the status code exists to
produce. `pkg/client.PutObject` was `checkStatus(resp, http.StatusCreated)`, an
exact match, so the new 202 arrived as an `*APIError` and `cmd/globalfs` printed
`error` for a committed write. The defect #130 describes still reached the only
first-party consumer of this API. Both halves were individually correct against
their own stubs while disagreeing with each other, which is why the last commit
adds a **round-trip test** that drives the real `objectPutHandler` over a real
socket with the real client — the assertion neither side's tests could make.

**How `PutObject` reports it.** An error wrapping a new
`client.ErrReplicationPending`, documented as a committed write that must not be
retried. Not a nil: a nil would claim durability the coordinator did not, which is
the same "success while something is wrong" shape as the original bug, inverted. A
sentinel rather than a new exported type or a changed signature, because it
matches how `internal/coordinator` already reports the condition
(`ErrReplicationNotQueued`) so one shape survives the whole trip; because
`errors.Is` answers the caller's only question with no string matching, no type
assertion, and stays correct under further wrapping; and because an unchanged
signature leaves every existing caller conservative by default — non-nil still
means "not fully successful" — while a caller who cares opts in.

**`checkStatus` was not changed.** Its job is "this code is wrong, here is why",
and 201 and 202 do not mean the same thing to the caller, so a multi-status form
would collapse them back into one and lose the distinction `PutObject` now exists
to report. `PutObject` branches before calling it. `ListObjects` already handles
its 207 that way; the two now match. This was also the smaller change.

The sentinel is driven by the status code, not the body — `putPartialDetail` falls
back to a fixed message on an absent or unparseable 202 body, so a proxy that
strips it still produces the right outcome with a vaguer explanation.

**What the CLI prints.** `object put` reports a 202 as stored, with the caveat on
stderr ("the object is stored and readable, do not re-upload it") and
`replication_pending` plus `detail` in `--json`. Stdout keeps the unchanged
success line so anything parsing it is unaffected, and the new JSON fields are
`omitempty` so a fully replicated write serialises exactly as before.

**Exit status stays 0**, and I'll argue it rather than assert it: a non-zero exit
is the only signal `set -e` and CI runners read, so it would make every one of
them treat a stored object as a failed step — the harm being fixed, relocated
from the message into the exit code. Replication lag is a condition of the
deployment, not of this command; the coordinator retries it, and it is now
visible in the text, in `--json`, and in the coordinator's logs and metrics. A
caller who does want to gate on it has `replication_pending`.

## #131 — POST /api/v1/sites refuses a duplicate name

Now goes through `AddSiteUnique` and maps `ErrDuplicateSite` to 409. Both traps
from the issue body handled.

*The rejected mount is closed.* Not closing it leaks the pool
`site.NewFromConfig` opened — #80's leak on a new path. The close lives in a new
`registerSite` function rather than inline, and that was forced by testability:
everything above it in the handler needs a real S3 endpoint to produce a
`*site.SiteMount` at all, so inline the reject-and-close path is unreachable from
a test and the close becomes an assertion nobody can make. `registerSite` takes a
mount directly.

*The name is checked before connecting.* `siteNameTaken` runs before endpoint
validation and `NewFromConfig`, so a duplicate POST no longer costs a DNS lookup
and a signed HeadBucket. Its doc comment says plainly that it races and is an
optimisation, not the decision; `AddSiteUnique`, doing check-and-append under one
lock hold, stays authoritative.
`TestAddSite_ConcurrentDuplicates_OnlyOneWins` keeps that honest — 16 goroutines
that all observe the name as free, 1 accepted, 15 closed.

## #132 — pkg/client refuses redirects and validates keys locally

Described as hardening, not a live hole: #73's server fix is merged and the
authorization boundary holds against a current coordinator. What this covers is a
current client against a pre-#73 or misconfigured coordinator, plus the general
problem that the API key was replayed to any redirect target at all (Go strips
sensitive headers across a host change but not on a same-host redirect, and gives
a custom Authorization-style header no special treatment either way).

`CheckRedirect` returns an error wrapping the new `ErrUnexpectedRedirect`, naming
both the original URL and the `Location`. An error rather than
`http.ErrUseLastResponse` on purpose: `ErrUseLastResponse` would surface a 307 as
an ordinary `*APIError` that every call site would then have to recognise as a
redirect itself, whereas an error means the follow-up request is never built, so
the key cannot reach the wire twice.

Object keys are validated before the URL is built, same rule as the server's
`validateObjectKey`, wrapping the new `ErrInvalidKey`.

The policy is applied after the options so `WithHTTPClient` is covered — that is
the path a caller most plausibly uses to install a custom Transport and it would
otherwise silently opt out. `New` copies the supplied client rather than mutating
it (the copy shares the Transport, so pooling and any custom RoundTripper
survive), since the caller's client may be shared with code that does want
redirects. A caller-supplied `CheckRedirect` is respected, including one that
follows: this is a default, not a prohibition.

## #83 / #84 — the daemon side of the lifecycle work (5th commit)

Agent A bounded the coordinator's own waits and gave `Start` and the setters
errors to return, but could not touch `cmd/coordinator/main.go`. `main.go` kept
compiling across that change, because ignoring a returned error is legal Go — which
is exactly what made both of these silent.

### Shutdown is now bounded

`cancel()` followed by an unbounded `c.Close()` meant a site whose connection-pool
drain never returned took SIGTERM with it. Now `CloseContext` under an explicit
30 s budget, with a non-zero exit on a timed-out teardown (#69's reasoning applied
to #83: the process is ending either way, but an abandoned transfer or an unclosed
site is not a clean shutdown, and `$?` is where that is legible).

**I verified the context-derivation detail rather than taking it on trust, and it
is real.** A timeout context derived from an already-cancelled parent is born
cancelled — `Err()` is non-nil immediately — so passing one to `CloseContext` makes
every bounded wait inside return at once: `Worker.StopContext` abandons the
in-flight transfer instead of letting it settle, and the terminal event goes
unemitted with the drain already gone. That is the phantom-job condition #78
fixed, so deriving would reintroduce a known bug *while looking like it was adding
a safety bound*. Confirmed in-repo against the real constant, and both directions
are now pinned by tests. `newShutdownContext` is a named function specifically so
the derivation is testable and has somewhere for the reasoning to live.

**On whether the outer 30 s is redundant with `defaultStopTimeout`: it is not, and
here is why.** `CloseContext` imposes its own default *only when the caller
supplies no deadline*, so the question is never "is a bound present" but "which
side owns it". It stays load-bearing for two reasons: the budget has to start at
the cancel, not at whenever `Close` is entered (correct today, wrong the moment
anything is inserted between them), and an explicit context puts the deadline
where a reader looking for it will be rather than making it a property of the
callee.

I also folded the HTTP drain onto the same constant — the two were separately
hardcoded to the same 30 s and a comment claimed they matched. They are
sequential, so **worst case from signal to exit is 2 × 30 s = 60 s**, which is now
stated at the call site because it constrains the termination grace period of
whatever supervises the process: set that below 60 s and the supervisor's SIGKILL
preempts the bounded shutdown entirely, making all of this moot.

### Five discarded lifecycle errors

`c.Start` was the serious one, and it is now fatal. The daemon would otherwise
have continued into its serving loop with no replication worker and no health
poller: writes reaching primaries and reported as stored, `/healthz` answering
from a cache nothing refreshes, and nothing in the log saying why — #84's silent
standby with a supervisor keeping the process alive. Exiting lets the supervisor
restart into a fresh coordinator, which is the only recovery a single-use
lifecycle permits.

The four setters go through a new `mustConfigure` and are **also fatal**, which I'll
argue since it's the less obvious half. They all run before `Start`, where the
contract is to return nil, so a non-nil error cannot be caused by anything in the
operator's config file — it means a setter moved below `Start`, i.e. a bug in this
file. Fatal rather than logged-and-continued because the value came from the
config file, so `config show` would keep reporting it while the daemon ran on the
default: precisely the divergence between reported and effective configuration
that #81 and the yaml-tag bug produced. A deployment is better off failing to boot
than running with a queue depth, lease TTL, or health cadence nobody chose. The
log names the setting as the operator knows it, not the Go method, since the
reader is likelier to have the YAML open than the source.

**`api_test.go` did have the same class of finding** — 10 of them (`c.Start` ×6,
`SetHealthPollInterval` ×3, `SetWorkerQueueDepth` ×1), which is the remainder A
attributed to my files. Not cosmetic there either: `mustStart`/`mustSet` mean a
refused call fails the test rather than leaving every later assertion to run
against a coordinator that is not running, or measuring a default in place of the
value the test set. Both helpers were verified to actually fire.

### What is not tested, said plainly

**The `os.Exit(1)` on a refused `Start` and on a refused setter is not covered.**
It is unreachable from a test in this package without restructuring `main()` into
an injectable `run() error` — a change well beyond these commits, touching every
path in a 300-line function that nothing currently covers. Rather than force it, I
tested the boundary: that `Start`'s refusal is produced, non-nil, and identifiable
via `errors.Is(err, coordinator.ErrStopped)` so the call site cannot be defeated by
a message change. The exit itself is reviewed, not tested. If you want it covered,
the `run() error` refactor is the way and it should be its own PR.

## Compatibility note for the CHANGELOG

**202 is a new response code for `PUT /api/v1/objects/{key...}`, so a pre-v0.2.3
`pkg/client` build talking to a v0.2.3 coordinator reports a committed write as an
error and may re-upload it.** `pkg/client` and the coordinator are versioned and
released together here, but nothing enforces that they are *deployed* together —
a pinned dependency in a downstream Go program, or an older `globalfs` binary on
an operator's machine, is enough. The failure is not silent (the caller gets
`coordinator error (202)`) and it is not a correctness problem for stored data,
but it does mean an unnecessary re-upload and a spurious failure in whatever is
calling. Worth a line in the release notes; raising it here rather than leaving it
to be found later.

Nothing needed on the coordinator side for this — a 202 is only produced when the
replication queue is saturated, so an older client sees it rarely and only under
load.

## Verified

All of the below is **with #136 merged in**, since the fifth commit does not
compile without it.

```
go build ./...                                       ok
go vet ./...                                         ok
gofmt -l .                                           empty
go test -race -timeout=10m ./...                     green, 16 packages (testcache cleaned)
golangci-lint run --new-from-merge-base=main         0 issues
go test -race -count=3 -cpu=1,2,4 ./cmd/coordinator  ok (68s)
```

Lint re-run repeatedly, including with `--max-same-issues=0
--max-issues-per-linter=0` after a `golangci-lint cache clean`, since the default
`max-same-issues=3` can hide more of a class right after a batch. Stable at 0. The
put tests and the new shutdown tests were run with `-count=5` under `-race`; the
two queue-saturation tests are the only timing-sensitive ones and neither flaked.

Every new test was confirmed failing against the prior behaviour, reverted in
place with the symbols left declared so these are assertions and not compile
errors. Real output:

- **#130 coordinator**: `got 502, want 202`, body `{"error":"coordinator: Put
  \"data/obj-02\": stored on primaries but replication not queued for [backup]:
  ..."}`
- **#130 client**: `PutObject error does not wrap ErrReplicationPending:
  &client.APIError{StatusCode:202, ...}`
- **#130 CLI** (client reverted): `object put reported a committed write as a
  failure: coordinator error (202): {...}` — the printed harm from the issue
- **#130 CLI** (CLI reverted only, client intact): `object put reported a
  committed write as a failure: put object "uploads/x": object stored but
  replication was not queued: ...` — so each half is independently load-bearing
- **#130 round trip** (client reverted, live `objectPutHandler`): `the
  coordinator's 202 did not reach the client as ErrReplicationPending`
- **#131**: duplicate POST returned `201` with `{"name":"primary",...}`;
  `registerSite` accepted a duplicate; 16 concurrent registrations of one name →
  16 accepted, 0 closed, coordinator left holding 17 sites
- **#132**: `DeleteObject returned nil against a 307`; `the API key was sent on 10
  requests, want 1` with all ten carrying `secret-key`; 90 requests for 9 calls
  across the methods, `HeadObject` reporting `stopped after 10 redirects`; 16
  requests sent for keys the server must refuse
- **#83 unbounded**: `newShutdownContext has no deadline; SIGTERM would rely on the
  coordinator's internal default instead of the daemon's own bound`
- **#83 wrong derivation** (against the real constant): `derived context is already
  done: context canceled` — the hazard, confirmed rather than assumed
- **#84 guards fire**: `coordinator.Start: coordinator: Start: coordinator stopped;
  a Coordinator is single-use` and `coordinator configuration worker queue depth
  was refused: coordinator: SetWorkerQueueDepth after Start (state=running)`

## Worth scrutinising

- **The #130 `detail` string is not machine-readable** on either side of the wire,
  and is deliberately not presented as such. If a caller needs the un-queued
  destinations programmatically, that wants a typed error out of
  `internal/coordinator`; I did not want to add a parser of another package's
  `%v` output in two places. Follow-up material.
- **`ErrReplicationPending` is a non-nil error for a successful write**, which is
  an unusual contract and rests on callers reading the doc comment. The
  alternative — nil plus an out-of-band signal — is worse, but this is the part
  most likely to be mis-handled by a future caller, and it is only enforced by
  documentation.
- **`object put` exiting 0 on a 202 is a judgement call.** Reasoning is above. If
  you disagree it is a one-line change, and the `--json` field is there either way.
- **`siteNameTaken` is O(sites) per POST and takes `Sites()`' RLock and
  allocation.** Fine at any plausible site count, and it replaces a network round
  trip, but it is a second traversal of the list on the happy path.
- **Two tests drive PUTs in a loop until one is refused** rather than assuming the
  second is, because the worker may not have dequeued the first job yet. Both give
  up after 10 and fail with a message saying so, so a future change that makes the
  queue never-full produces a clear failure rather than a hang.
- **`registerSite` exists partly for testability.** I think it earns its keep on
  the doc comment alone (the close is the subtle part and it now has somewhere to
  be explained), but it is an extra indirection in a handler that was flat.
- **#132 rejects keys with a `..` component outright rather than escaping them.**
  `data/..` is a legal S3 key that this API cannot route, so the client refusing
  it matches the server's 400 — but it is a client-side behaviour change for
  anyone who was somehow relying on it. `TestObjectKey_LegitimateKeysStillWork`
  pins the near misses (`data/..hidden`, `a..b/c`, `.hidden`) as still sent.
- `cmd/globalfs` has its own `httpClient` for two raw `apiGet` calls
  (`/api/v1/info`, `/healthz`) that do not go through `pkg/client`. Both are GETs
  to fixed paths, so neither is the #132 shape — noting it so it is not assumed
  covered.
- **A refused setter now prevents the daemon from booting.** That is the intent,
  but it converts a previously-silent condition into a hard failure, so if there
  is a deployment out there where a setter is somehow reached after `Start`, it
  will stop starting rather than quietly misbehaving. I believe that is
  unreachable in the current `main()` — every setter is above `Start` — which is
  why the log says it is a daemon bug rather than a config problem.
- **60 s worst-case shutdown is a behaviour change for supervisors.** Previously
  the coordinator half was unbounded (so: could hang forever), and now it is
  bounded but the two windows are sequential. Anything with a termination grace
  period under 60 s should be checked; there is no config knob for either window.
- **The `os.Exit` paths are untested**, per the section above. That is a deliberate
  scope call, not an oversight.

`internal/coordinator` and `internal/replication` were not modified by me;
`AddSiteUnique`, `ErrDuplicateSite`, `ErrReplicationNotQueued`, `ErrStopped`,
`CloseContext` and the new setter signatures were all used exactly as #136 exports
them. The lifecycle branch appears in this PR only as a merge commit.
`cmd/globalfs/main.go` was touched only at the one `PutObject` call site (plus the
`objectPutResult` struct and the `errors` import it needs), per the extension
granted for it. `CHANGELOG.md` deliberately untouched — hence the compatibility
note above being in this description rather than in the file.

Not merging.

