### PR TITLE
fix: v0.2.3 coordinator lifecycle (#82, #83, #84, #85, #86, #95)

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -17,8 +17,49 @@
 //
 // # Lifecycle
 //
-// Call Start to begin background replication processing, then Stop (or Close)
-// when done.  Coordinator is safe for concurrent use.
+// A Coordinator is **single-use**.  It moves through three states, in one
+// direction only, and never returns to an earlier one:
+//
+//	created --Start--> running --Stop--> stopped
+//	created ---------------Stop--------> stopped
+//
+// The rules that follow from that, all enforced rather than merely documented:
+//
+//   - **Start is idempotent and reports failure.**  It returns nil on the call
+//     that starts the coordinator (or that enters standby, which is a successful
+//     start with no worker), and nil again for every later call on a running
+//     coordinator.  It returns an error wrapping [ErrStopped] on a stopped one.
+//   - **Stop before Start is legal and terminal.**  It is a no-op on goroutines
+//     that do not exist, but it *does* move the coordinator to stopped, so a
+//     later Start fails loudly instead of running with replication silently off.
+//     Callers that stop defensively during a failed boot get an error they can
+//     act on rather than a healthy-looking coordinator that replicates nothing
+//     (#84).
+//   - **Stop-then-Start is illegal**, and the error says so.  Restarting would
+//     mean rebuilding the worker, its queue, its done channel and every
+//     in-flight job's context; a fresh [New] is the supported way to get a
+//     working coordinator, and it costs nothing but the site list.
+//   - **Start and Stop are ordered with respect to each other.**  Both transition
+//     the same `state` field under `c.mu`, so a Stop racing a Start either loses
+//     (Start wins, Stop then tears down what Start built) or wins (Start is
+//     refused and launches nothing).  It cannot land in between and leave
+//     goroutines nobody can cancel, which is what a nil `storeCancel` plus a
+//     zero `storeWg` used to allow — 59 of 60 races leaked a drain goroutine
+//     (#82).
+//   - **Configuration is frozen at Start.**  Every Set* method that Start reads
+//     once — SetStore, SetMetrics, SetWorkerQueueDepth, SetLeaseManager,
+//     SetLeaseTTL, SetHealthPollInterval — returns an error wrapping
+//     [ErrStarted] if called after Start, instead of mutating state the running
+//     goroutines have already copied (#85, #86).  The genuinely dynamic
+//     knobs — SetPolicy, SetCache, SetCircuitBreaker, SetRetryConfig,
+//     SetEnqueueBackpressure — stay callable at any time and return nothing.
+//
+// Stop and Close wait for the in-flight replication transfer to settle, which is
+// unbounded if the destination site is unresponsive.  Use [Coordinator.StopContext]
+// to bound that wait; a caller that must terminate (a SIGTERM handler) should
+// always use the bounded form (#83).
+//
+// Coordinator is safe for concurrent use.
 package coordinator
 
 import (
@@ -58,12 +99,38 @@ type Coordinator struct {
 	store        metadata.Store   // optional; nil means no persistence
 	m            *metrics.Metrics // optional; nil means no instrumentation
 	storeCancel  context.CancelFunc
-	storeWg      sync.WaitGroup
-	startOnce    sync.Once          // ensures Start() body runs exactly once
 	leaseManager *lease.Manager     // optional; nil means single-node mode
 	leaderLease  *lease.Lease       // non-nil when this instance is the leader
 	leaderCancel context.CancelFunc // cancels the leaderCtx
 	leaseTTL     time.Duration      // 0 → defaultLeaseTTL
+
+	// state is the coordinator's position in its one-directional lifecycle; see
+	// the package Lifecycle doc.  It replaced a sync.Once plus the nil-ness of
+	// storeCancel and the zero-ness of a shared WaitGroup, which between them
+	// could not order Start against Stop at all (#82, #84, #85).  Guarded by
+	// c.mu, the same lock every Set* method takes, so "has Start read this yet?"
+	// is one question with one answer rather than a per-field guess.
+	state coordState
+
+	// lifecycleMu serializes a whole Start against a whole Stop.
+	//
+	// c.mu cannot do this job: Start must release it across the lease
+	// acquisition and across recoverPendingJobs, both of which do I/O, and it is
+	// also the lock every in-flight Get and Put takes — holding it for the
+	// duration of a shutdown is exactly the availability problem #95 is about.
+	// A separate lifecycle lock keeps Start and Stop mutually exclusive without
+	// making either of them exclude ordinary traffic.
+	//
+	// Ordering rule: acquire lifecycleMu before c.mu, never the reverse.
+	lifecycleMu sync.Mutex
+
+	// drainWg tracks the worker-event drain goroutine; healthWg tracks the health
+	// poller.  Separate because Stop has to distinguish them: the final event
+	// flush is safe only once the drain has returned, and a health poller wedged
+	// in a probe that ignores its context must not be able to veto that flush.
+	// One shared WaitGroup made a stuck probe cost buffered replication events.
+	drainWg  sync.WaitGroup
+	healthWg sync.WaitGroup
 
 	// Background health polling.
 	healthPollInterval time.Duration // 0 → use defaultHealthPollInterval
@@ -84,6 +151,61 @@ type Coordinator struct {
 	// 0 → defaultEnqueueBackpressure.  Overridden in tests to keep them fast.
 	enqueueBackpressure time.Duration
 }
+
+// coordState is the coordinator's position in its one-directional lifecycle.
+// See the package Lifecycle doc for the contract it enforces.
+type coordState int
+
+const (
+	// coordCreated is a Coordinator that has never been started.
+	coordCreated coordState = iota
+	// coordRunning is a Coordinator whose Start has been accepted.  Standby
+	// counts: the lease was lost or held elsewhere, so no worker runs, but the
+	// coordinator started successfully and Stop still has work to undo.
+	coordRunning
+	// coordStopped is terminal.  Start on it returns ErrStopped.
+	coordStopped
+)
+
+func (s coordState) String() string {
+	switch s {
+	case coordCreated:
+		return "created"
+	case coordRunning:
+		return "running"
+	case coordStopped:
+		return "stopped"
+	default:
+		return fmt.Sprintf("coordState(%d)", int(s))
+	}
+}
+
+// ErrStarted reports that a configuration call arrived after Start, at which
+// point the value it sets has already been read and copied by the background
+// goroutines.  Such a call is a no-op, logged at Error; the sentinel exists so a
+// caller that wants to check first can, and so the message has one spelling.
+var ErrStarted = errors.New("coordinator already started")
+
+// ErrStopped reports that Start was called on a stopped Coordinator.
+//
+// A Coordinator is single-use: Stop is terminal even when it ran before Start
+// ever did.  A caller that stops defensively during a failed boot and then
+// starts must construct a new Coordinator with [New]; the alternative — a Start
+// that appears to succeed while replication is off for the process lifetime — is
+// the failure #84 describes, and this error is what makes it visible.
+var ErrStopped = errors.New("coordinator stopped; a Coordinator is single-use")
+
+// defaultStopTimeout bounds Stop and Close when the caller supplies no deadline
+// of their own.
+//
+// Unbounded was the previous behaviour and it is how a single unresponsive S3
+// endpoint kept the process alive past its SIGTERM grace period until the
+// orchestrator SIGKILLed it, discarding the in-memory replication queue (#83).
+// 30 s is chosen to sit inside a typical 60 s terminationGracePeriodSeconds with
+// room for the HTTP drain that precedes it, and to be long enough that a
+// genuinely slow-but-progressing transfer finishes rather than being abandoned.
+// Callers that know their own budget should pass it via StopContext/CloseContext.
+const defaultStopTimeout = 30 * time.Second
 
 // defaultHealthPollInterval is the cadence for background site health checks
 // when no explicit interval has been set via SetHealthPollInterval.
@@ -215,32 +337,50 @@ func recordSiteResult(cb *circuitbreaker.Breaker, name string, err error) {
 }
 
 // ── Metrics helpers ───────────────────────────────────────────────────────────
-// These wrappers centralise the nil check so call sites stay clean.
+//
+// Every *metrics.Metrics method is nil-safe on the receiver, so these wrappers
+// exist purely to funnel every read of c.m through metrics(), which does it under
+// the lock.  Reading the field directly was the race in #86: SetMetrics writes it
+// under c.mu, and an unsynchronized read of an interface-shaped field can observe
+// a non-nil type word with a stale data word, so the nil check passes and the call
+// dereferences garbage.  The nil checks the wrappers used to perform are gone
+// because they were never the load-bearing part — Metrics does them itself.
 
-func (c *Coordinator) metricsCacheHit() {
-	if c.m != nil {
-		c.m.RecordCacheHit()
-	}
+// metrics returns the registered Metrics, or nil.  The nil is safe to call
+// methods on; every *metrics.Metrics method returns early on a nil receiver.
+func (c *Coordinator) metrics() *metrics.Metrics {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.m
 }
-func (c *Coordinator) metricsCacheMiss() {
-	if c.m != nil {
-		c.m.RecordCacheMiss()
-	}
-}
-func (c *Coordinator) metricsCacheEviction() {
-	if c.m != nil {
-		c.m.RecordCacheEviction()
-	}
-}
-func (c *Coordinator) metricsCacheBytes(n int64) {
-	if c.m != nil {
-		c.m.SetCacheBytes(n)
-	}
-}
-func (c *Coordinator) metricsSiteCount(n int) {
-	if c.m != nil {
-		c.m.SetSiteCount(n)
-	}
+
+func (c *Coordinator) metricsCacheHit()          { c.metrics().RecordCacheHit() }
+func (c *Coordinator) metricsCacheMiss()         { c.metrics().RecordCacheMiss() }
+func (c *Coordinator) metricsCacheEviction()     { c.metrics().RecordCacheEviction() }
+func (c *Coordinator) metricsCacheBytes(n int64) { c.metrics().SetCacheBytes(n) }
+
+// metricsSiteCountLocked records the site count.  Unlike its siblings this one is
+// called from AddSite/RemoveSite with c.mu already held for writing, so it reads
+// the field directly — taking RLock here would deadlock on Go's non-reentrant
+// RWMutex.
+func (c *Coordinator) metricsSiteCountLocked(n int) { c.m.SetSiteCount(n) }
+
+// workerRef returns the replication worker under the read lock.
+//
+// SetWorkerQueueDepth writes c.worker under c.mu; Put, Replicate,
+// ReplicationQueueDepth and the event drain all used to read it without any lock,
+// which is a pointer race regardless of how benign the timing looks — the second
+// half of #85, and confirmed by -race on the exported
+// ReplicationQueueDepth/SetWorkerQueueDepth pair alone.  Gating the setter on
+// started-state narrows the window but does not close it: two goroutines can still
+// configure and read a *created* coordinator concurrently.
+//
+// The pointer is stable for the whole running lifetime, so callers may hold the
+// returned value across a long operation; the lock is only needed to read it.
+func (c *Coordinator) workerRef() *replication.Worker {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.worker
 }
 
 // New creates a Coordinator from an ordered list of SiteMounts.
@@ -273,15 +413,46 @@ func (c *Coordinator) SetPolicy(e *policy.Engine) {
 	}
 }
 
+// setBeforeStart applies fn under c.mu, but only while the coordinator is still
+// in the created state.
+//
+// It is the single gate behind every configuration setter whose value Start reads
+// once and hands to a goroutine.  Mutating such a field afterwards cannot take
+// effect — the goroutine already has its copy — so the honest outcomes are an
+// error and a no-op, not a silent write to a field nobody will read again.  What
+// it replaces is a set of methods that documented one behaviour ("no effect after
+// Start") and implemented another, of which SetWorkerQueueDepth was the
+// destructive case: it replaced a *running* worker, leaking its goroutine and
+// leaving the new one unstarted, so every subsequent Enqueue filled a queue
+// nobody drained while Put kept returning nil (#85).
+//
+// The error is logged here as well as returned.  Every shipped call site is in
+// cmd/coordinator before Start, where this returns nil; a call that arrives after
+// Start is a caller bug, and the log is what makes it visible even to a caller
+// that discards the error.
+func (c *Coordinator) setBeforeStart(name string, fn func()) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch c.state {
+	case coordRunning, coordStopped:
+		err := fmt.Errorf("coordinator: %s after Start (state=%s): %w", name, c.state, ErrStarted)
+		slog.Error("coordinator: configuration call ignored", "call", name, "state", c.state.String())
+		return err
+	}
+	fn()
+	return nil
+}
+
 // SetStore registers a metadata store for persistence.
 //
 // When set, replication jobs are persisted before they are enqueued so they
 // survive coordinator restarts.  Completed and failed jobs are deleted from
-// the store.  SetStore must be called before Start to enable job recovery.
-func (c *Coordinator) SetStore(s metadata.Store) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.store = s
+// the store.
+//
+// Must be called before Start; returns an error wrapping [ErrStarted] otherwise,
+// having changed nothing.
+func (c *Coordinator) SetStore(s metadata.Store) error {
+	return c.setBeforeStart("SetStore", func() { c.store = s })
 }
 
 // SetLeaseManager registers a distributed lease manager.
@@ -291,43 +462,54 @@ func (c *Coordinator) SetStore(s metadata.Store) {
 // worker is not started and the coordinator operates in standby mode (writes
 // still reach primary sites synchronously, but async replication is skipped).
 //
-// SetLeaseManager must be called before Start.
-func (c *Coordinator) SetLeaseManager(mgr *lease.Manager) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.leaseManager = mgr
+// Must be called before Start; returns an error wrapping [ErrStarted] otherwise,
+// having changed nothing.
+func (c *Coordinator) SetLeaseManager(mgr *lease.Manager) error {
+	return c.setBeforeStart("SetLeaseManager", func() { c.leaseManager = mgr })
 }
 
 // SetMetrics registers a Metrics instance with the coordinator.
 // When set, site-count and replication event metrics are emitted automatically.
-// SetMetrics must be called before Start to instrument replication events.
-func (c *Coordinator) SetMetrics(m *metrics.Metrics) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.m = m
+//
+// Must be called before Start; returns an error wrapping [ErrStarted] otherwise,
+// having changed nothing.  Freezing it at Start is what closes the #86 race:
+// every read now goes through c.metrics() under the lock, and the field stops
+// changing at the moment concurrent readers appear.
+func (c *Coordinator) SetMetrics(m *metrics.Metrics) error {
+	return c.setBeforeStart("SetMetrics", func() { c.m = m })
 }
 
 // SetHealthPollInterval sets the interval between background site health
 // checks.  The default is 30 seconds.  Pass 0 to use the default.
-// Must be called before Start.
-func (c *Coordinator) SetHealthPollInterval(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.healthPollInterval = d
+//
+// Must be called before Start; returns an error wrapping [ErrStarted] otherwise,
+// having changed nothing.
+func (c *Coordinator) SetHealthPollInterval(d time.Duration) error {
+	return c.setBeforeStart("SetHealthPollInterval", func() { c.healthPollInterval = d })
 }
 
 // SetLeaseTTL sets the TTL used when acquiring the distributed leader lease.
 // When 0 (the default), defaultLeaseTTL (15 s) is used.
-// Must be called before Start.
-func (c *Coordinator) SetLeaseTTL(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.leaseTTL = d
+//
+// Must be called before Start; returns an error wrapping [ErrStarted] otherwise,
+// having changed nothing.
+func (c *Coordinator) SetLeaseTTL(d time.Duration) error {
+	return c.setBeforeStart("SetLeaseTTL", func() { c.leaseTTL = d })
 }
 
 // SetWorkerQueueDepth configures the replication worker queue depth.
-// Must be called before Start; has no effect if Start has already been called.
 // Pass 0 to retain the existing depth (default 512).
+//
+// Must be called before Start; returns an error wrapping [ErrStarted] otherwise,
+// having changed nothing.  This is the setter #85 is about: it used to replace
+// c.worker unconditionally, so calling it on a running coordinator orphaned the
+// goroutine that was draining the queue and installed a fresh worker that nobody
+// would ever Start.  Replication stopped permanently and Put went on returning
+// nil.  Erroring is the right resolution rather than making the depth genuinely
+// reconfigurable: the queue's capacity is the buffer of a channel created by
+// NewWorker, growing it means a new channel, and a new channel means either
+// discarding the jobs in the old one or draining two queues with one worker.
+// The one shipped caller (cmd/coordinator) sets it once at boot.
 //
 // Note that this is a *queue depth*, not a concurrency limit — the worker is a
 // single serial goroutine.  The shipped daemon passes
@@ -336,12 +518,12 @@ func (c *Coordinator) SetLeaseTTL(d time.Duration) {
 // setting is a config change and belongs elsewhere; Put now applies
 // backpressure rather than dropping writes, so the small depth costs latency
 // under a burst instead of data (#79).
-func (c *Coordinator) SetWorkerQueueDepth(depth int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if depth > 0 {
-		c.worker = replication.NewWorker(depth)
-	}
+func (c *Coordinator) SetWorkerQueueDepth(depth int) error {
+	return c.setBeforeStart("SetWorkerQueueDepth", func() {
+		if depth > 0 {
+			c.worker = replication.NewWorker(depth)
+		}
+	})
 }
 
 // SetEnqueueBackpressure bounds how long Put waits for room in the replication
@@ -433,38 +615,89 @@ func (c *Coordinator) runHealthPoll(ctx context.Context) {
 	c.healthCacheMu.Unlock()
 }
 
-// Start launches the background replication worker.
-// It is safe to call Start multiple times; only the first call has effect.
+// Start launches the background replication worker and the health poller.
+//
+// It returns nil on the call that starts the coordinator and nil again for every
+// later call on a running one, so Start is idempotent for callers that do not
+// coordinate among themselves.  It returns an error wrapping [ErrStopped] if the
+// coordinator has been stopped — including stopped before it was ever started.
+// A Coordinator is single-use; see the package Lifecycle doc.
+//
+// Start used to return nothing and to be guarded by a sync.Once, which made
+// "started" and "refused" indistinguishable.  The Once had no relationship to
+// Stop's state at all: Stop-then-Start launched the drain and the health poller
+// while silently leaving the worker dead, so replication was off for the process
+// lifetime with the coordinator reporting healthy and Put returning success
+// (#84).  Returning an error is what lets a caller notice.
 //
 // If a LeaseManager has been registered via SetLeaseManager, Start attempts to
-// acquire the "coordinator/leader" lease.  Only the leader starts the worker;
-// if another instance already holds the lease this coordinator enters standby
-// mode and Start returns without launching any background goroutines.
+// acquire the "coordinator/leader" lease.  Only the leader starts the worker; if
+// another instance already holds the lease this coordinator enters standby mode.
+// Standby is a *successful* start — the coordinator is running, it just has no
+// worker — so Start returns nil and Stop still has the drain and poller to undo.
 //
 // If a Store has been registered via SetStore, Start also recovers any pending
-// jobs from the previous run and begins draining worker events to keep the
-// store in sync.
-func (c *Coordinator) Start(ctx context.Context) {
-	c.startOnce.Do(func() { c.start(ctx) })
-}
+// jobs from the previous run and begins draining worker events to keep the store
+// in sync.
+func (c *Coordinator) Start(ctx context.Context) error {
+	// lifecycleMu serializes Start against Stop for their whole duration, which
+	// is the invariant #82 was missing.  c.mu alone cannot provide it: Start has
+	// to release c.mu across the lease acquisition (a network call) and across
+	// recoverPendingJobs, and a Stop that slipped into that window saw
+	// storeCancel still nil and storeWg still zero, concluded there was nothing
+	// to stop, and returned — after which Start launched a drain goroutine and a
+	// health poller under a context nothing would ever cancel.  59 of 60 races
+	// leaked a pair.
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
 
-// start is the internal implementation of Start; called exactly once via startOnce.
-func (c *Coordinator) start(ctx context.Context) {
 	c.mu.Lock()
-	mgr := c.leaseManager
-	store := c.store
-	leaseTTL := c.leaseTTL
-	pollInterval := c.healthPollInterval
+	switch c.state {
+	case coordRunning:
+		c.mu.Unlock()
+		return nil
+	case coordStopped:
+		c.mu.Unlock()
+		return fmt.Errorf("coordinator: Start: %w", ErrStopped)
+	}
+	// Claim the running state and freeze the configuration in one lock hold, so
+	// no Set* call can land between the check and the read.
+	c.state = coordRunning
+	cfg := startConfig{
+		mgr:          c.leaseManager,
+		store:        c.store,
+		leaseTTL:     c.leaseTTL,
+		pollInterval: c.healthPollInterval,
+		worker:       c.worker,
+	}
 	c.mu.Unlock()
 
+	c.launch(ctx, cfg)
+	return nil
+}
+
+// startConfig is the snapshot of configuration Start takes under c.mu and hands
+// to launch.  Grouping it makes the freeze-at-Start rule visible: these fields
+// are read once, here, and every Set* that writes them refuses afterwards.
+type startConfig struct {
+	mgr          *lease.Manager
+	store        metadata.Store
+	leaseTTL     time.Duration
+	pollInterval time.Duration
+	worker       *replication.Worker
+}
+
+// launch does the work of Start.  Callers must hold c.lifecycleMu.
+func (c *Coordinator) launch(ctx context.Context, cfg startConfig) {
 	// workerCtx is cancelled when the lease is lost (if a lease manager is set).
 	workerCtx := ctx
 
-	if mgr != nil {
+	if cfg.mgr != nil {
+		leaseTTL := cfg.leaseTTL
 		if leaseTTL <= 0 {
 			leaseTTL = defaultLeaseTTL
 		}
-		l, acquired, err := mgr.TryAcquire(ctx, "coordinator/leader", leaseTTL)
+		l, acquired, err := cfg.mgr.TryAcquire(ctx, "coordinator/leader", leaseTTL)
 		if err != nil {
 			slog.Warn("coordinator: acquire leader lease; running in standby mode", "error", err)
 			return
@@ -503,44 +736,69 @@ func (c *Coordinator) start(ctx context.Context) {
 	c.storeCancel = drainCancel
 	c.mu.Unlock()
 
-	if store != nil {
-		c.recoverPendingJobs(workerCtx, store)
+	if cfg.store != nil {
+		c.recoverPendingJobs(workerCtx, cfg.store)
 	}
-	c.storeWg.Add(1)
+
+	// The drain and the health poller get separate WaitGroups because Stop needs
+	// to know which of them finished.  The final flush is only safe once the
+	// drain has returned — two readers would split the event buffer between them
+	// (#78) — and one WaitGroup for both means a health poller stuck in an
+	// unresponsive site's probe makes Stop unable to tell whether flushing is
+	// safe, so it would have to skip a flush it could have done.
+	c.drainWg.Add(1)
 	go func() {
-		defer c.storeWg.Done()
-		c.drainWorkerEvents(drainCtx, store)
+		defer c.drainWg.Done()
+		c.drainWorkerEvents(drainCtx, cfg.store)
 	}()
 
 	// Launch background health polling goroutine.
 	// Uses drainCtx so it stops when Stop() is called (via storeCancel).
-	// pollInterval was read from c.healthPollInterval under c.mu at the top.
+	pollInterval := cfg.pollInterval
 	if pollInterval <= 0 {
 		pollInterval = defaultHealthPollInterval
 	}
-	c.storeWg.Add(1)
+	c.healthWg.Add(1)
 	go func() {
-		defer c.storeWg.Done()
-		c.runHealthPoll(drainCtx) // immediate first check
-		ticker := time.NewTicker(pollInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				c.runHealthPoll(drainCtx)
-			case <-drainCtx.Done():
-				return
-			}
-		}
+		defer c.healthWg.Done()
+		c.runHealthPollLoop(drainCtx, pollInterval)
 	}()
 
-	c.worker.Start(workerCtx)
+	cfg.worker.Start(workerCtx)
+}
+
+// runHealthPollLoop polls site health until ctx is cancelled.
+//
+// It is a named method rather than the closure it used to be so that it appears
+// as a stable frame in a goroutine dump: the leak assertions for #82 identify the
+// coordinator's background goroutines by function name, which is the only way to
+// tell them apart from those of other tests running in the same process.
+func (c *Coordinator) runHealthPollLoop(ctx context.Context, interval time.Duration) {
+	c.runHealthPoll(ctx) // immediate first check
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.runHealthPoll(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // Stop signals the background replication worker to stop and waits for it to
 // finish the current job.  If a leader lease is held it is released so that a
-// standby coordinator can take over immediately.  Calling Stop before Start is
-// safe.
+// standby coordinator can take over immediately.
+//
+// Stop before Start is legal and is terminal: nothing is torn down because
+// nothing was built, but the coordinator moves to stopped and a later Start
+// returns [ErrStopped].  Calling Stop more than once is safe.
+//
+// Stop bounds itself at defaultStopTimeout (30 s).  Use [Coordinator.StopContext]
+// to supply your own budget.  Unbounded was the old behaviour, and it is how one
+// unresponsive S3 endpoint kept a SIGTERMed process alive until the orchestrator
+// SIGKILLed it (#83).
 //
 // # Teardown order
 //
@@ -549,40 +807,90 @@ func (c *Coordinator) start(ctx context.Context) {
 // drain goroutine is torn down first there is nobody left to read it, and the
 // job stays in the store as a phantom while its content hash is lost (#78).
 func (c *Coordinator) Stop() {
+	if err := c.StopContext(context.Background()); err != nil {
+		slog.Error("coordinator: Stop did not complete within the default budget",
+			"timeout", defaultStopTimeout, "error", err)
+	}
+}
+
+// StopContext is Stop with a caller-supplied deadline.  It returns nil when
+// shutdown completed, or an error wrapping ctx.Err() when the budget elapsed
+// first.
+//
+// If ctx carries no deadline, defaultStopTimeout is imposed — the same treatment
+// [Coordinator.Health] gives its own context, and for the same reason: an
+// unbounded wait on a remote endpoint is a liveness bug, not a configuration
+// choice.
+//
+// # What a non-nil error means
+//
+// The coordinator *is* stopped either way: the state transition, the worker's
+// stop signal and both context cancellations all happen before anything is
+// waited on, so no new work starts.  What the error reports is that shutdown gave
+// up *observing* the finish, so one or more of these may still be true:
+//
+//   - a replication transfer is still parked inside a site's PUT, and its
+//     terminal event will be emitted with nobody left to read it (so a persisted
+//     job may be re-enqueued on the next start — which is correct, if wasteful);
+//   - a health probe is still inside the objectfs connection pool's own 30 s
+//     wait, which is not context-aware.
+//
+// Those goroutines are abandoned, not cancelled.  Neither transfer nor probe
+// becomes interruptible because shutdown would like it to be, so the choice is a
+// leaked goroutine in a process that is terminating, or a process that never
+// terminates.  This picks the first, and returns the error so the caller can log
+// it and set a non-zero exit code (#69's reasoning applied to #83).
+func (c *Coordinator) StopContext(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultStopTimeout)
+		defer cancel()
+	}
+
+	// Held for the whole of Stop, so a concurrent Start either completes before
+	// this begins (and is torn down) or is refused after it (#82).
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+
 	c.mu.Lock()
+	c.state = coordStopped
 	storeCancel := c.storeCancel
 	leaderCancel := c.leaderCancel
 	l := c.leaderLease
+	c.leaderLease = nil // so a second Stop does not double-release
 	store := c.store
+	worker := c.worker
 	c.mu.Unlock()
+
+	var errs []error
 
 	// 1. Stop the producer.  Returns once the in-flight job has settled, so
 	//    every terminal event it will ever emit is buffered by the time this
 	//    returns.  The events channel is buffered to the queue depth, so emit
 	//    cannot block even with no reader currently scheduled.
-	c.worker.Stop()
+	if err := worker.StopContext(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("replication worker did not settle: %w", err))
+	}
 
 	// 2. Now the consumer.  Cancelling these stops the drain goroutine, the
 	//    health poller, and the lease keepalive.
 	//
-	//    Note for #83: leaderCancel used to run first, and because leaderCtx is
-	//    the worker's ctx that gave the in-flight transfer a cancellation path.
-	//    It no longer does — deliberately, since aborting the transfer is the
-	//    opposite of letting it settle.  Bounding a transfer against an
-	//    unresponsive site is #83's job and wants a real timeout; it was never
-	//    covered in the no-lease-manager case anyway, which is every shipped
-	//    deployment.  cmd/coordinator cancels the root context before calling
-	//    Close, so the transfer ctx is already done by the time Stop is entered.
+	//    leaderCancel deliberately does not run first.  leaderCtx is the worker's
+	//    ctx, so cancelling it before step 1 would abort the in-flight transfer
+	//    instead of letting it settle, which is the opposite of what #78 needs.
+	//    It was also never a bound in the no-lease-manager case, which is every
+	//    shipped deployment; the bound is now the ctx above.
 	if leaderCancel != nil {
 		leaderCancel()
 	}
 	if storeCancel != nil {
 		storeCancel()
 	}
-	c.storeWg.Wait()
 
-	// 3. Final flush on this goroutine.  storeWg.Wait above guarantees the drain
-	//    goroutine has returned, so there is no concurrent reader.
+	// 3. Wait for the drain, then flush on this goroutine.  The wait is what
+	//    makes the flush safe: flushWorkerEvents and a live drain would split the
+	//    event buffer between them.  If the wait times out the flush is skipped
+	//    rather than raced.
 	//
 	//    Step 1 plus the drain's own flush covers the common case, but not the
 	//    one the shipped daemon actually produces: cmd/coordinator cancels the
@@ -591,14 +899,53 @@ func (c *Coordinator) Stop() {
 	//    after a lost leader lease, which cancels leaderCtx with no Stop
 	//    involved.  Flushing here makes the guarantee independent of who
 	//    cancelled what first, which is worth more than the one non-blocking
-	//    channel read it costs when the buffer is empty.
-	c.flushWorkerEvents(store)
+	//    channel read it costs when the buffer is empty (#78).
+	if err := waitBounded(ctx, &c.drainWg); err != nil {
+		errs = append(errs, fmt.Errorf("event drain did not exit, skipping final flush: %w", err))
+	} else {
+		c.flushWorkerEvents(store)
+	}
+
+	// 4. The health poller.  Waited on separately because it is the goroutine
+	//    most likely to be stuck — objectfs's connection pool ignores the probe
+	//    context and waits up to 30 s of its own (#83) — and letting that block
+	//    the flush decision above would cost data for no reason.
+	if err := waitBounded(ctx, &c.healthWg); err != nil {
+		errs = append(errs, fmt.Errorf("health poller did not exit: %w", err))
+	}
 
 	// Release the leader lease last so a standby can take over quickly.
 	if l != nil {
 		if err := l.Release(); err != nil {
 			slog.Warn("coordinator: release leader lease", "error", err)
+			errs = append(errs, fmt.Errorf("release leader lease: %w", err))
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("coordinator: Stop: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// waitBounded waits for wg, giving up when ctx ends.
+//
+// sync.WaitGroup has no context-aware Wait, so the wait runs on its own
+// goroutine.  That goroutine outlives a timed-out call for exactly as long as the
+// work it is waiting on does; see StopContext for why abandoning it is the right
+// trade.  Every Add on these WaitGroups happens inside Start, which holds
+// c.lifecycleMu, so the Add-before-Wait requirement holds by construction.
+func waitBounded(ctx context.Context, wg *sync.WaitGroup) error {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -623,7 +970,7 @@ func (c *Coordinator) AddSite(s *site.SiteMount) {
 	defer c.mu.Unlock()
 	c.sites = append(c.sites, s)
 	c.ns.AddSite(s)
-	c.metricsSiteCount(len(c.sites))
+	c.metricsSiteCountLocked(len(c.sites))
 }
 
 // ErrDuplicateSite reports that a site with the requested name is already
@@ -648,7 +995,7 @@ func (c *Coordinator) AddSiteUnique(s *site.SiteMount) error {
 	}
 	c.sites = append(c.sites, s)
 	c.ns.AddSite(s)
-	c.metricsSiteCount(len(c.sites))
+	c.metricsSiteCountLocked(len(c.sites))
 	return nil
 }
 
@@ -685,7 +1032,7 @@ func (c *Coordinator) RemoveSite(name string) bool {
 		return false
 	}
 	c.ns = namespace.New(c.sites...)
-	c.metricsSiteCount(len(c.sites))
+	c.metricsSiteCountLocked(len(c.sites))
 	c.mu.Unlock()
 
 	// Close outside the lock: Close talks to the network and can block, and
@@ -706,11 +1053,39 @@ func (c *Coordinator) Sites() []*site.SiteMount {
 	return cp
 }
 
+// ErrHealthTimeout marks a site whose health probe had not answered when Health's
+// context expired.  It means "unknown", not "unhealthy" — but for routing and for
+// /health the two are treated the same, which is the safe direction.
+var ErrHealthTimeout = errors.New("health check did not answer before the deadline")
+
 // Health returns a per-site health report.
 // A nil error means the site is healthy; checks run concurrently.
 //
-// If ctx carries no deadline, a defaultHealthTimeout deadline is imposed so
-// that per-site goroutines cannot block indefinitely on unreachable sites.
+// If ctx carries no deadline, defaultHealthTimeout is imposed.
+//
+// # The report is bounded, the probes are not
+//
+// Health returns when every probe has answered *or* when ctx expires, whichever
+// comes first, and a site that has not answered by then is reported with
+// [ErrHealthTimeout].  It used to wait unconditionally for every goroutine, which
+// made the deadline a request rather than a guarantee: a probe that ignores its
+// context pinned the wait open, and because the background poller runs under the
+// same call, that pinned Stop open too — one unresponsive endpoint and SIGTERM
+// never completed (#83).
+//
+// The probes do ignore their context, which is why this matters rather than being
+// belt-and-braces.  SiteMount.Health calls objectfs's Client.Health, which reaches
+// Backend.HealthCheck → ClientManager.HealthCheck, and that acquires a pooled S3
+// client via ConnectionPool.Get() *before* it makes the ctx-aware HeadBucket call.
+// Get is hard-coded to GetWithTimeout(30 * time.Second) and takes no context at
+// all, so a saturated pool blocks the probe for up to 30 s no matter what deadline
+// the caller set.  Verified by reading objectfs v0.12.0: internal/storage/s3/
+// client.go:239-256 and pool.go:111-201.
+//
+// A timed-out probe is therefore abandoned, not cancelled.  It writes its result
+// into a channel this function has already stopped reading; the channel is
+// buffered to the site count so the write cannot block, and the goroutine exits on
+// its own once the underlying call returns.
 func (c *Coordinator) Health(ctx context.Context) map[string]error {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
@@ -722,22 +1097,36 @@ func (c *Coordinator) Health(ctx context.Context) map[string]error {
 	snapshot := c.snapshotSites()
 	c.mu.RUnlock()
 
-	result := make(map[string]error, len(snapshot))
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
+	type probeResult struct {
+		name string
+		err  error
+	}
+	// Buffered to len(snapshot): an abandoned probe must be able to complete its
+	// send and exit rather than leaking on a blocked channel write forever.
+	results := make(chan probeResult, len(snapshot))
 	for _, s := range snapshot {
-		s := s
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
-			err := s.Health(ctx)
-			mu.Lock()
-			result[s.Name()] = err
-			mu.Unlock()
+			results <- probeResult{name: s.Name(), err: s.Health(ctx)}
 		}()
 	}
-	wg.Wait()
+
+	result := make(map[string]error, len(snapshot))
+	for i := 0; i < len(snapshot); i++ {
+		select {
+		case r := <-results:
+			result[r.name] = r.err
+		case <-ctx.Done():
+			// Fill in every site that has not answered.  Reporting them as
+			// timed-out rather than omitting them keeps the report's key set equal
+			// to the site set, which SiteInfos and preferHealthySites both assume.
+			for _, s := range snapshot {
+				if _, ok := result[s.Name()]; !ok {
+					result[s.Name()] = fmt.Errorf("%w: %w", ErrHealthTimeout, ctx.Err())
+				}
+			}
+			return result
+		}
+	}
 	return result
 }
 
@@ -844,7 +1233,7 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 	c.mu.RLock()
 	snapshot, pol, store, cb, oc := c.snapshotSites(), c.policy, c.store, c.cb, c.objCache
-	m, backpressure := c.m, c.enqueueBackpressure
+	m, backpressure, worker := c.m, c.enqueueBackpressure, c.worker
 	c.mu.RUnlock()
 
 	routed, err := pol.Route(policy.OperationWrite, key, snapshot)
@@ -915,7 +1304,7 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 					continue
 				}
 			}
-			if enqErr := c.enqueueWithBackpressure(ctx, backpressure, replication.ReplicationJob{
+			if enqErr := enqueueWithBackpressure(ctx, worker, backpressure, replication.ReplicationJob{
 				SourceSite: src,
 				DestSite:   s,
 				Key:        key,
@@ -927,7 +1316,7 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 				// error to the caller and a counter rather than a log line.
 				m.RecordReplicationDropped()
 				slog.Error("coordinator: replication queue full; write not replicated",
-					"key", key, "dest", s.Name(), "queue_depth", c.worker.QueueDepth(), "error", enqErr)
+					"key", key, "dest", s.Name(), "queue_depth", worker.QueueDepth(), "error", enqErr)
 				notQueued = append(notQueued, s.Name())
 				if notQueuedCause == nil {
 					notQueuedCause = enqErr
@@ -956,14 +1345,19 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 	return nil
 }
 
-// enqueueWithBackpressure submits job to the replication worker, waiting up to
-// budget for queue room.  A budget of 0 means defaultEnqueueBackpressure; a
-// negative budget means a single attempt with no wait.
+// enqueueWithBackpressure submits job to worker, waiting up to budget for queue
+// room.  A budget of 0 means defaultEnqueueBackpressure; a negative budget means
+// a single attempt with no wait.
 //
 // Returns nil once the job is queued, or the worker's queue-full error if the
 // budget elapses.  A cancelled ctx aborts the wait and returns ctx.Err().
-func (c *Coordinator) enqueueWithBackpressure(ctx context.Context, budget time.Duration, job replication.ReplicationJob) error {
-	err := c.worker.Enqueue(job)
+//
+// The worker is a parameter rather than read from the receiver so that the caller
+// reads c.worker once, under the lock, and the whole backpressure loop then works
+// against that one worker.  Re-reading the field per retry would have been the
+// pointer race in #85 with extra steps.
+func enqueueWithBackpressure(ctx context.Context, worker *replication.Worker, budget time.Duration, job replication.ReplicationJob) error {
+	err := worker.Enqueue(job)
 	if err == nil || budget < 0 {
 		return err
 	}
@@ -986,7 +1380,7 @@ func (c *Coordinator) enqueueWithBackpressure(ctx context.Context, budget time.D
 		case <-deadline.C:
 			return err // the last queue-full error
 		case <-ticker.C:
-			if err = c.worker.Enqueue(job); err == nil {
+			if err = worker.Enqueue(job); err == nil {
 				return nil
 			}
 		}
@@ -1171,7 +1565,7 @@ func (c *Coordinator) Replicate(ctx context.Context, key, fromSite, toSite strin
 		return fmt.Errorf("coordinator: replicate: destination site %q not found", toSite)
 	}
 
-	if err := c.worker.Enqueue(replication.ReplicationJob{
+	if err := c.workerRef().Enqueue(replication.ReplicationJob{
 		SourceSite: src,
 		DestSite:   dst,
 		Key:        key,
@@ -1186,7 +1580,7 @@ func (c *Coordinator) Replicate(ctx context.Context, key, fromSite, toSite strin
 // ReplicationQueueDepth returns the number of replication jobs currently
 // waiting in the worker queue.
 func (c *Coordinator) ReplicationQueueDepth() int {
-	return c.worker.QueueDepth()
+	return c.workerRef().QueueDepth()
 }
 
 // IsLeader reports whether this coordinator instance is currently the active
@@ -1310,6 +1704,7 @@ func makeJobID(sourceSite, destSite, key string) string {
 // recoverPendingJobs reads all pending replication jobs from the store and
 // re-enqueues them.  Called at Start time when a store is configured.
 func (c *Coordinator) recoverPendingJobs(ctx context.Context, store metadata.Store) {
+	worker := c.workerRef()
 	jobs, err := store.GetPendingJobs(ctx)
 	if err != nil {
 		slog.Error("coordinator: recover pending jobs", "error", err)
@@ -1330,7 +1725,7 @@ func (c *Coordinator) recoverPendingJobs(ctx context.Context, store metadata.Sto
 			slog.Warn("coordinator: skip recovered job (site missing)", "job_id", j.ID)
 			continue
 		}
-		if err := c.worker.Enqueue(replication.ReplicationJob{
+		if err := worker.Enqueue(replication.ReplicationJob{
 			SourceSite: src,
 			DestSite:   dst,
 			Key:        j.Key,
@@ -1350,9 +1745,10 @@ func (c *Coordinator) recoverPendingJobs(ctx context.Context, store metadata.Sto
 // emitted, which is the same loss #78 describes in a narrower window: the
 // buffered EventCompleted of a transfer that finished a moment before shutdown.
 func (c *Coordinator) drainWorkerEvents(ctx context.Context, store metadata.Store) {
+	events := c.workerRef().Events()
 	for {
 		select {
-		case ev, ok := <-c.worker.Events():
+		case ev, ok := <-events:
 			if !ok {
 				return
 			}
@@ -1371,9 +1767,10 @@ func (c *Coordinator) drainWorkerEvents(ctx context.Context, store metadata.Stor
 // Callers must ensure no other goroutine is reading Events() concurrently, or
 // the two will split the buffer between them.
 func (c *Coordinator) flushWorkerEvents(store metadata.Store) {
+	events := c.workerRef().Events()
 	for {
 		select {
-		case ev, ok := <-c.worker.Events():
+		case ev, ok := <-events:
 			if !ok {
 				return
 			}
@@ -1419,11 +1816,10 @@ func (c *Coordinator) handleWorkerEvent(ev replication.ReplicationEvent, store m
 		}
 	}
 
-	c.mu.RLock()
-	m := c.m
-	c.mu.RUnlock()
-	if m != nil {
-		m.RecordReplication(string(ev.Type))
-		m.SetReplicationQueueDepth(c.worker.QueueDepth())
-	}
+	// Both reads go through the locked accessors: c.m is written by SetMetrics
+	// under c.mu (#86) and c.worker by SetWorkerQueueDepth under c.mu (#85), and
+	// this runs on the drain goroutine concurrently with both.
+	m := c.metrics()
+	m.RecordReplication(string(ev.Type))
+	m.SetReplicationQueueDepth(c.workerRef().QueueDepth())
 }

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -56,8 +56,8 @@
 //
 // Stop and Close wait for the in-flight replication transfer to settle, which is
 // unbounded if the destination site is unresponsive.  Use [Coordinator.StopContext]
-// to bound that wait; a caller that must terminate (a SIGTERM handler) should
-// always use the bounded form (#83).
+// or [Coordinator.CloseContext] to bound that wait; a caller that must terminate
+// (a SIGTERM handler) should always use the bounded form (#83).
 //
 // Coordinator is safe for concurrent use.
 package coordinator
@@ -950,11 +950,98 @@ func waitBounded(ctx context.Context, wg *sync.WaitGroup) error {
 }
 
 // Close stops background work and closes all sites.
+//
+// It bounds itself at defaultStopTimeout (30 s); use [Coordinator.CloseContext]
+// to supply your own budget.  Close is idempotent: the second call finds no sites
+// and returns whatever the stop reported.
 func (c *Coordinator) Close() error {
-	c.Stop()
+	return c.CloseContext(context.Background())
+}
+
+// CloseContext is Close with a caller-supplied deadline.  It stops background
+// work and then closes every site, returning the joined errors of both halves.
+//
+// # Why the sites are closed outside c.mu
+//
+// A site's Close is a network operation — connection-pool drain, in-flight
+// request completion — with no bound on how long it takes.  Holding c.mu across
+// it blocked every method that touches the site set, including Sites() and the
+// /health handler behind it, for the full duration: measured at over two seconds
+// against one slow site, which an orchestrator polling health during a rolling
+// restart reads as a hung process rather than a draining one (#95).
+//
+// So this follows the pattern [Coordinator.RemoveSite] already uses: snapshot
+// under the lock, clear the set inside the same critical section so a concurrent
+// request sees an empty site list rather than a half-closed one, and do the
+// teardown after releasing.  Clearing inside the critical section is also what
+// keeps Close idempotent.
+//
+// The closes run concurrently and are bounded by ctx for the same reason the
+// worker wait is: one unresponsive endpoint must not be able to prevent the
+// process from terminating (#83).  A close that outruns the budget is abandoned
+// and reported.
+func (c *Coordinator) CloseContext(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultStopTimeout)
+		defer cancel()
+	}
+
+	var errs []error
+	if err := c.StopContext(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.ns.Close()
+	sites := c.snapshotSites()
+	c.sites = nil
+	// c.ns is replaced rather than closed: it holds the same *SiteMount pointers
+	// as c.sites, so closing both would close every site twice.  An empty
+	// Namespace keeps every c.ns.* call site nil-safe.
+	c.ns = namespace.New()
+	c.mu.Unlock()
+
+	if err := closeSites(ctx, sites); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// closeSites closes every site concurrently and waits up to ctx for them.
+// Returns the joined per-site errors, plus ctx.Err() if the budget elapsed with
+// closes still outstanding.
+func closeSites(ctx context.Context, sites []*site.SiteMount) error {
+	if len(sites) == 0 {
+		return nil
+	}
+
+	// Buffered to len(sites) so a close that finishes after the deadline can still
+	// deliver its result and exit instead of blocking on the send forever.
+	results := make(chan error, len(sites))
+	for _, s := range sites {
+		go func() {
+			if err := s.Close(); err != nil {
+				results <- fmt.Errorf("close site %q: %w", s.Name(), err)
+				return
+			}
+			results <- nil
+		}()
+	}
+
+	var errs []error
+	for i := 0; i < len(sites); i++ {
+		select {
+		case err := <-results:
+			if err != nil {
+				errs = append(errs, err)
+			}
+		case <-ctx.Done():
+			errs = append(errs, fmt.Errorf("%d of %d site close(s) did not finish: %w",
+				len(sites)-i, len(sites), ctx.Err()))
+			return errors.Join(errs...)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // AddSite appends a site at the lowest priority, without checking whether its

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -49,14 +49,17 @@ type memClient struct {
 	// started, and polling the destination for the key cannot tell it — the key
 	// only appears once the gate is released.
 	putsEntered int
-	// healthGate is the same device for Health.  It deliberately ignores the
-	// caller's context, because that is what the real stack does: objectfs's
-	// ClientManager.HealthCheck acquires a pooled client through
-	// ConnectionPool.Get, which takes no context and waits up to 30 s of its own
-	// before the ctx-aware HeadBucket is ever reached.  A gate that honoured ctx
-	// would make the shutdown-bound tests pass for the wrong reason (#83).
+	// healthGate and closeGate are the same device for Health and Close.  They
+	// deliberately ignore the caller's context, because that is what the real
+	// stack does: objectfs's ClientManager.HealthCheck acquires a pooled client
+	// through ConnectionPool.Get, which takes no context and waits up to 30 s of
+	// its own before the ctx-aware HeadBucket is ever reached.  A gate that
+	// honoured ctx would make the shutdown-bound tests pass for the wrong reason
+	// (#83, #95).
 	healthGate    chan struct{}
 	healthEntered int
+	closeGate     chan struct{}
+	closeEntered  int
 	// closes counts Close calls, so tests can assert that removing a site
 	// releases exactly the resources it took (#80).
 	closes int
@@ -189,6 +192,13 @@ func (m *memClient) Health(_ context.Context) error {
 
 func (m *memClient) Close() error {
 	m.mu.Lock()
+	gate := m.closeGate
+	m.closeEntered++
+	m.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.closes++
 	return nil
@@ -230,6 +240,16 @@ func (m *memClient) blockHealth() (release func()) {
 	return func() { once.Do(func() { close(gate) }) }
 }
 
+// blockCloses makes every subsequent Close on this client wait.
+func (m *memClient) blockCloses() (release func()) {
+	gate := make(chan struct{})
+	m.mu.Lock()
+	m.closeGate = gate
+	m.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
+}
+
 // waitForPut blocks until at least n Put calls have reached the gate, or the
 // timeout elapses (reported as a fatal test failure).
 func (m *memClient) waitForPut(t *testing.T, n int, timeout time.Duration) {
@@ -241,6 +261,12 @@ func (m *memClient) waitForPut(t *testing.T, n int, timeout time.Duration) {
 func (m *memClient) waitForHealth(t *testing.T, n int, timeout time.Duration) {
 	t.Helper()
 	m.waitForEntry(t, "Health", n, timeout, func() int { return m.healthEntered })
+}
+
+// waitForClose blocks until at least n Closes have reached the gate.
+func (m *memClient) waitForClose(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	m.waitForEntry(t, "Close", n, timeout, func() int { return m.closeEntered })
 }
 
 // waitForEntry polls count (called under m.mu) until it reaches n, or fails.
@@ -3393,6 +3419,106 @@ func TestCoordinator_Health_ReportsTimedOutSitesAsUnknown(t *testing.T) {
 	}
 	if err := report["fast"]; err != nil {
 		t.Errorf("report[fast]: got %v, want nil — a fast site must not be tarred with the slow one", err)
+	}
+}
+
+// TestCoordinator_Close_DoesNotBlockSitesDuringSlowClose is #95.
+//
+// Close held c.mu for writing across every site's Close, and a site Close is a
+// network operation — pool drain, in-flight request completion — with no bound.
+// Every method that touches the site set therefore blocked for the full duration,
+// including Sites() and the /health handler behind it: measured at over two
+// seconds against one slow site, which an orchestrator polling health during a
+// rolling restart reads as a hung process rather than a draining one.
+func TestCoordinator_Close_DoesNotBlockSitesDuringSlowClose(t *testing.T) {
+	t.Parallel()
+
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, _ := makeMount("backup", types.SiteRoleBackup, nil)
+
+	release := primaryClient.blockCloses()
+	defer release()
+
+	c := New(primary, backup)
+
+	closed := make(chan error, 1)
+	go func() { closed <- c.Close() }()
+
+	// Close must have reached the site teardown, so the assertion below is made
+	// while the slow close is genuinely in flight.
+	primaryClient.waitForClose(t, 1, 2*time.Second)
+
+	// Sites() takes c.mu.RLock.  If Close still held the write lock this would
+	// block until the gate is released, which is after this test's assertion.
+	blocked := make(chan int, 1)
+	go func() { blocked <- len(c.Sites()) }()
+
+	select {
+	case <-blocked:
+		// Good: the lock was free.  The value is unimportant — Close clears the
+		// site list inside its critical section, so 0 is the expected answer and
+		// getting any answer at all is the point.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Sites() blocked while a site close was in flight — Close is holding c.mu " +
+			"across per-site network teardown (#95), so /health hangs for the duration")
+	}
+
+	release()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return within 5s after the slow site was released")
+	}
+}
+
+// TestCoordinator_CloseContext_BoundedWhenSiteCloseWedged is #95's other half:
+// having moved the closes outside the lock, they still must not be unbounded, or
+// one dead endpoint prevents the process from exiting.
+func TestCoordinator_CloseContext_BoundedWhenSiteCloseWedged(t *testing.T) {
+	t.Parallel()
+
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, nil)
+	release := primaryClient.blockCloses()
+	defer release()
+
+	c := New(primary)
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer closeCancel()
+
+	start := time.Now()
+	err := c.CloseContext(closeCtx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("CloseContext returned nil while a site close was wedged")
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("CloseContext took %v with a 200ms budget — an unresponsive endpoint can still "+
+			"hold the process open (#83)", elapsed)
+	}
+}
+
+// TestCoordinator_Close_Idempotent guards the consequence of clearing the site
+// list inside Close's critical section: a second Close must not close every site
+// twice, which for a real client is a double-free of its connection pool.
+func TestCoordinator_Close_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(primary)
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if got := primaryClient.closeCount(); got != 1 {
+		t.Errorf("site Close called %d times across two coordinator Closes, want 1", got)
 	}
 }
 

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -47,6 +49,14 @@ type memClient struct {
 	// started, and polling the destination for the key cannot tell it — the key
 	// only appears once the gate is released.
 	putsEntered int
+	// healthGate is the same device for Health.  It deliberately ignores the
+	// caller's context, because that is what the real stack does: objectfs's
+	// ClientManager.HealthCheck acquires a pooled client through
+	// ConnectionPool.Get, which takes no context and waits up to 30 s of its own
+	// before the ctx-aware HeadBucket is ever reached.  A gate that honoured ctx
+	// would make the shutdown-bound tests pass for the wrong reason (#83).
+	healthGate    chan struct{}
+	healthEntered int
 	// closes counts Close calls, so tests can assert that removing a site
 	// releases exactly the resources it took (#80).
 	closes int
@@ -167,8 +177,14 @@ func (m *memClient) hasKey(key string) bool {
 
 func (m *memClient) Health(_ context.Context) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.healthErr
+	gate := m.healthGate
+	m.healthEntered++
+	err := m.healthErr
+	m.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+	return err
 }
 
 func (m *memClient) Close() error {
@@ -204,26 +220,68 @@ func (m *memClient) blockPuts() (release func()) {
 	return func() { once.Do(func() { close(gate) }) }
 }
 
+// blockHealth makes every subsequent Health probe on this client wait.
+func (m *memClient) blockHealth() (release func()) {
+	gate := make(chan struct{})
+	m.mu.Lock()
+	m.healthGate = gate
+	m.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
+}
+
 // waitForPut blocks until at least n Put calls have reached the gate, or the
 // timeout elapses (reported as a fatal test failure).
 func (m *memClient) waitForPut(t *testing.T, n int, timeout time.Duration) {
 	t.Helper()
+	m.waitForEntry(t, "Put", n, timeout, func() int { return m.putsEntered })
+}
+
+// waitForHealth blocks until at least n Health probes have reached the gate.
+func (m *memClient) waitForHealth(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	m.waitForEntry(t, "Health", n, timeout, func() int { return m.healthEntered })
+}
+
+// waitForEntry polls count (called under m.mu) until it reaches n, or fails.
+func (m *memClient) waitForEntry(t *testing.T, what string, n int, timeout time.Duration, count func() int) {
+	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		m.mu.Lock()
-		entered := m.putsEntered
+		entered := count()
 		m.mu.Unlock()
 		if entered >= n {
 			return
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
-	t.Fatalf("no Put reached the client within %v — the transfer never started", timeout)
+	t.Fatalf("fewer than %d %s call(s) reached the client within %v", n, what, timeout)
 }
 
 func makeMount(name string, role types.SiteRole, objs map[string][]byte) (*site.SiteMount, *memClient) {
 	mc := newMemClient(objs)
 	return site.New(name, role, mc), mc
+}
+
+// mustStart starts the coordinator and fails the test if it refuses.
+//
+// Start returns an error now (#84), and a test that discards it would silently
+// exercise an unstarted coordinator — which is the exact failure mode these fixes
+// are about, so it must not be possible to reintroduce it by inattention.
+func mustStart(t *testing.T, ctx context.Context, c *Coordinator) {
+	t.Helper()
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+}
+
+// mustConfigure asserts that a Set* call before Start was accepted.
+func mustConfigure(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("configuration call before Start was rejected: %v", err)
+	}
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -334,7 +392,7 @@ func TestCoordinator_Put_AsyncReplicatesToBackup(t *testing.T) {
 	defer cancel()
 
 	c := New(primary, backup)
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	if err := c.Put(ctx, "data.fastq", []byte("genome-data")); err != nil {
@@ -722,7 +780,7 @@ func TestCoordinator_SetPolicy_Put_RoutesToBurst(t *testing.T) {
 	defer cancel()
 
 	c := New(primaryMount, burstMount)
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Policy: *.tmp writes → burst only (primary is not in TargetRoles).
@@ -845,11 +903,11 @@ func TestCoordinator_SetWorkerQueueDepth(t *testing.T) {
 	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
 
 	c := New(src, dst)
-	c.SetWorkerQueueDepth(4) // small depth to verify it's applied
+	mustConfigure(t, c.SetWorkerQueueDepth(4)) // small depth to verify it's applied
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	if err := c.Put(ctx, "k", []byte("v")); err != nil {
@@ -873,11 +931,11 @@ func TestCoordinator_SetLeaseTTL_NoLeaseManager(t *testing.T) {
 
 	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
 	c := New(primary)
-	c.SetLeaseTTL(30 * time.Second) // must not panic; no lease manager set
+	mustConfigure(t, c.SetLeaseTTL(30*time.Second)) // must not panic; no lease manager set
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 }
 
@@ -905,8 +963,8 @@ func TestCoordinator_SetStore_PersistsReplicationJob(t *testing.T) {
 
 	store := metadata.NewMemoryStore()
 	c := New(primary, backup)
-	c.SetStore(store)
-	c.Start(ctx)
+	mustConfigure(t, c.SetStore(store))
+	mustStart(t, ctx, c)
 	// Defers run LIFO, so this releases the blocked transfer *before* Stop runs.
 	// The reverse order would have Stop wait on a worker parked inside Put, which
 	// is the shutdown hang tracked in #83.
@@ -954,8 +1012,8 @@ func TestCoordinator_SetStore_DeletesJobAfterReplication(t *testing.T) {
 
 	store := metadata.NewMemoryStore()
 	c := New(primary, backup)
-	c.SetStore(store)
-	c.Start(ctx)
+	mustConfigure(t, c.SetStore(store))
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	if err := c.Put(ctx, "output.vcf", []byte("variant-calls")); err != nil {
@@ -1016,8 +1074,8 @@ func TestCoordinator_SetStore_RecoversPendingJobs(t *testing.T) {
 
 	// Start the coordinator; recoverPendingJobs should re-enqueue the job.
 	c := New(primary, backup)
-	c.SetStore(store)
-	c.Start(ctx)
+	mustConfigure(t, c.SetStore(store))
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Backup should eventually receive the recovered replication.
@@ -1046,8 +1104,8 @@ func TestCoordinator_Put_StoreFailureSkipsEnqueue(t *testing.T) {
 
 	store := &failingPutJobStore{MemoryStore: metadata.NewMemoryStore()}
 	c := New(primary, backup)
-	c.SetStore(store)
-	c.Start(ctx)
+	mustConfigure(t, c.SetStore(store))
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	if err := c.Put(ctx, "genome.bam", []byte("data")); err != nil {
@@ -1100,10 +1158,10 @@ func TestCoordinator_Put_FullQueueDoesNotReportSuccess(t *testing.T) {
 
 	const depth = 2
 	c := New(primary, backup)
-	c.SetWorkerQueueDepth(depth)
+	mustConfigure(t, c.SetWorkerQueueDepth(depth))
 	// Keep the test quick; the default 2 s budget × N Puts is not worth waiting for.
 	c.SetEnqueueBackpressure(50 * time.Millisecond)
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	// LIFO: release the blocked transfer before Stop, or Stop parks on a worker
 	// inside Put and the test hangs instead of failing (#83).
 	defer c.Stop()
@@ -1153,9 +1211,9 @@ func TestCoordinator_Put_ErrReplicationNotQueuedIsDistinguishable(t *testing.T) 
 	defer release()
 
 	c := New(primary, backup)
-	c.SetWorkerQueueDepth(1)
+	mustConfigure(t, c.SetWorkerQueueDepth(1))
 	c.SetEnqueueBackpressure(-1) // no waiting: fail the first full Enqueue
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 	defer release()
 
@@ -1206,8 +1264,8 @@ func TestCoordinator_Put_BackpressureWaitsForRoom(t *testing.T) {
 	defer cancel()
 
 	c := New(primary, backup)
-	c.SetWorkerQueueDepth(1) // pathologically small; the worker drains it fast
-	c.Start(ctx)
+	mustConfigure(t, c.SetWorkerQueueDepth(1)) // pathologically small; the worker drains it fast
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	const total = 20
@@ -1244,9 +1302,9 @@ func TestCoordinator_Put_BackpressureRespectsContextCancellation(t *testing.T) {
 	defer release()
 
 	c := New(primary, backup)
-	c.SetWorkerQueueDepth(1)
+	mustConfigure(t, c.SetWorkerQueueDepth(1))
 	c.SetEnqueueBackpressure(time.Hour) // would hang without cancellation
-	c.Start(startCtx)
+	mustStart(t, startCtx, c)
 	defer c.Stop()
 	defer release()
 
@@ -1299,10 +1357,10 @@ func TestCoordinator_Put_FullQueueIncrementsDroppedCounter(t *testing.T) {
 
 	reg := prometheus.NewRegistry()
 	c := New(primary, backup)
-	c.SetMetrics(metrics.New(reg))
-	c.SetWorkerQueueDepth(1)
+	mustConfigure(t, c.SetMetrics(metrics.New(reg)))
+	mustConfigure(t, c.SetWorkerQueueDepth(1))
 	c.SetEnqueueBackpressure(-1)
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 	defer release()
 
@@ -1353,9 +1411,9 @@ func TestCoordinator_Put_NoStore_FullQueueStillReports(t *testing.T) {
 	defer release()
 
 	c := New(primary, backup) // no SetStore
-	c.SetWorkerQueueDepth(1)
+	mustConfigure(t, c.SetWorkerQueueDepth(1))
 	c.SetEnqueueBackpressure(-1)
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 	defer release()
 
@@ -1397,8 +1455,8 @@ func TestCoordinator_Stop_WhileTransferInFlight_SettlesTheJob(t *testing.T) {
 
 	store := metadata.NewMemoryStore()
 	c := New(primary, backup)
-	c.SetStore(store)
-	c.Start(ctx)
+	mustConfigure(t, c.SetStore(store))
+	mustStart(t, ctx, c)
 
 	const key = "data/sample.bam"
 	if err := c.Put(ctx, key, []byte("genome")); err != nil {
@@ -1477,8 +1535,8 @@ func TestCoordinator_Stop_DrainFlushesBufferedEvents(t *testing.T) {
 
 	store := metadata.NewMemoryStore()
 	c := New(primary, backup)
-	c.SetStore(store)
-	c.Start(ctx)
+	mustConfigure(t, c.SetStore(store))
+	mustStart(t, ctx, c)
 
 	const key = "reads.fastq"
 	if err := c.Put(ctx, key, []byte("sequence")); err != nil {
@@ -1490,8 +1548,9 @@ func TestCoordinator_Stop_DrainFlushesBufferedEvents(t *testing.T) {
 	// release the transfer.  The completion event is emitted into a buffer with
 	// no live reader; Stop's final flush is the only thing that can consume it.
 	cancel()
-	// Wait for the drain and the health poller to observe the cancellation.
-	c.storeWg.Wait()
+	// Wait for the drain to observe the cancellation.  The health poller has its
+	// own WaitGroup now and is irrelevant here.
+	c.drainWg.Wait()
 	release()
 
 	c.Stop()
@@ -1544,8 +1603,8 @@ func TestCoordinator_SetLeaseManager_LeaderReplicates(t *testing.T) {
 
 	mgr := lease.NewMemoryManager("coord-1")
 	c := New(primary, backup)
-	c.SetLeaseManager(mgr)
-	c.Start(ctx)
+	mustConfigure(t, c.SetLeaseManager(mgr))
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	if err := c.Put(ctx, "data/reads.bam", []byte("genome")); err != nil {
@@ -1584,8 +1643,8 @@ func TestCoordinator_SetLeaseManager_StandbySkipsWorker(t *testing.T) {
 
 	// coord-2 starts with mgr2 — it will be in standby mode.
 	c := New(primary, backup)
-	c.SetLeaseManager(mgr2)
-	c.Start(ctx)
+	mustConfigure(t, c.SetLeaseManager(mgr2))
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Sync write to primary should still succeed.
@@ -1613,8 +1672,8 @@ func TestCoordinator_SetLeaseManager_LeaseLossStopsWorker(t *testing.T) {
 
 	mgr := lease.NewMemoryManager("coord-1")
 	c := New(primary, backup)
-	c.SetLeaseManager(mgr)
-	c.Start(ctx)
+	mustConfigure(t, c.SetLeaseManager(mgr))
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Verify the coordinator is operating as leader.
@@ -1678,10 +1737,10 @@ func TestCoordinator_HealthStatus_PopulatedAfterPoll(t *testing.T) {
 	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
 	c := New(primary)
 	// Use a very short poll interval so the test doesn't wait 30s.
-	c.SetHealthPollInterval(20 * time.Millisecond)
+	mustConfigure(t, c.SetHealthPollInterval(20*time.Millisecond))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Wait up to 500ms for the first poll to complete.
@@ -1700,11 +1759,11 @@ func TestCoordinator_HealthStatus_ReflectsUnhealthySite(t *testing.T) {
 	t.Parallel()
 	primary, mc := makeMount("primary", types.SiteRolePrimary, nil)
 	c := New(primary)
-	c.SetHealthPollInterval(20 * time.Millisecond)
+	mustConfigure(t, c.SetHealthPollInterval(20*time.Millisecond))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Wait for first (healthy) poll.
@@ -1734,11 +1793,11 @@ func TestCoordinator_SetHealthPollInterval_StopsWithStop(t *testing.T) {
 	t.Parallel()
 	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
 	c := New(primary)
-	c.SetHealthPollInterval(10 * time.Millisecond)
+	mustConfigure(t, c.SetHealthPollInterval(10*time.Millisecond))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 
 	// Stop should return quickly without hanging on the polling goroutine.
 	done := make(chan struct{})
@@ -1834,10 +1893,10 @@ func TestCoordinator_Get_SkipsDegradedPrimary(t *testing.T) {
 	})
 
 	c := New(primary, backup)
-	c.SetHealthPollInterval(10 * time.Millisecond)
+	mustConfigure(t, c.SetHealthPollInterval(10*time.Millisecond))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Wait for health cache to show primary as degraded.
@@ -1870,10 +1929,10 @@ func TestCoordinator_Get_FallsBackToDegradedWhenAllDegraded(t *testing.T) {
 	primaryClient.setHealthErr(errors.New("degraded"))
 
 	c := New(primary)
-	c.SetHealthPollInterval(10 * time.Millisecond)
+	mustConfigure(t, c.SetHealthPollInterval(10*time.Millisecond))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	// Wait for cache to mark primary degraded.
@@ -1911,10 +1970,10 @@ func TestCoordinator_Head_SkipsDegradedSite(t *testing.T) {
 	})
 
 	c := New(primary, backup)
-	c.SetHealthPollInterval(10 * time.Millisecond)
+	mustConfigure(t, c.SetHealthPollInterval(10*time.Millisecond))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.Start(ctx)
+	mustStart(t, ctx, c)
 	defer c.Stop()
 
 	deadline := time.Now().Add(500 * time.Millisecond)
@@ -2777,4 +2836,581 @@ func TestSiteInfos_MultipleSites(t *testing.T) {
 	if stateByName["site-b"] != "open" {
 		t.Errorf("site-b: got %q, want %q", stateByName["site-b"], "open")
 	}
+}
+
+// ─── Lifecycle tests (#82, #83, #84, #85, #86, #95) ───────────────────────────
+//
+// This block exists because the suite had a hole exactly the shape of five bugs:
+// nothing called Stop against a busy coordinator, and nothing called any Set*
+// after Start.  Every test here does one of those two things.
+
+// coordinatorGoroutines counts live goroutines whose stack mentions one of the
+// coordinator's background loops.
+//
+// Counting *all* goroutines would be useless here: the package's tests are
+// parallel, so the total is dominated by unrelated work and by the runtime's own
+// goroutines.  Matching frame names is what makes the count attributable, and it
+// is why runHealthPollLoop and drainWorkerEvents are named methods rather than
+// closures.
+func coordinatorGoroutines() int {
+	buf := make([]byte, 1<<20)
+	buf = buf[:runtime.Stack(buf, true)]
+	n := 0
+	for _, frame := range []string{
+		"coordinator.(*Coordinator).runHealthPollLoop",
+		"coordinator.(*Coordinator).drainWorkerEvents",
+	} {
+		n += strings.Count(string(buf), frame)
+	}
+	return n
+}
+
+// waitForGoroutines waits for the coordinator background goroutine count to fall
+// to want, and reports the last observation if it never does.  Polling rather than
+// sleeping is what makes this an assertion on the count instead of on a duration.
+func waitForGoroutines(t *testing.T, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var got int
+	for time.Now().Before(deadline) {
+		got = coordinatorGoroutines()
+		if got <= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("coordinator background goroutines: got %d, want <= %d after %v — they were leaked",
+		got, want, timeout)
+}
+
+// TestCoordinator_Lifecycle_ConcurrentStartStop_DoesNotLeak is #82.
+//
+// Start could not be ordered against Stop: Start released c.mu across the lease
+// acquisition and recoverPendingJobs, and a Stop that landed in that window read
+// storeCancel==nil and a zero storeWg, concluded there was nothing to tear down,
+// and returned — after which Start launched a drain goroutine and a health poller
+// under a context nothing would ever cancel.  Both leaked for the process
+// lifetime, the poller waking every interval to probe sites forever.
+//
+// The assertion is on the goroutine count, not on elapsed time: a leak is a
+// goroutine that is still there, and no sleep can prove its absence.
+func TestCoordinator_Lifecycle_ConcurrentStartStop_DoesNotLeak(t *testing.T) {
+	// Not parallel: it reads the process-wide goroutine dump, and a parallel
+	// sibling starting a coordinator would be counted as this test's leak.
+	baseline := coordinatorGoroutines()
+
+	const iterations = 60
+	for i := 0; i < iterations; i++ {
+		primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+		backup, _ := makeMount("backup", types.SiteRoleBackup, nil)
+		c := New(primary, backup)
+		// A short interval makes a leaked poller cheap to detect and expensive to
+		// ignore — it keeps probing after the coordinator is gone.
+		mustConfigure(t, c.SetHealthPollInterval(5*time.Millisecond))
+		mustConfigure(t, c.SetStore(metadata.NewMemoryStore()))
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Either outcome is contractual: Start won the race (nil) or Stop did
+			// (ErrStopped).  What is not contractual is Start launching goroutines
+			// that Stop has already decided not to wait for.
+			if err := c.Start(ctx); err != nil && !errors.Is(err, ErrStopped) {
+				t.Errorf("iteration %d: Start: unexpected error %v", i, err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			c.Stop()
+		}()
+		wg.Wait()
+
+		// The context is cancelled only *after* both calls return.  Cancelling
+		// earlier would let ctx.Done tear down a leaked goroutine and hide the bug —
+		// which is precisely what the daemon's `cancel(); c.Close()` does, and why
+		// this leak survived in production without being noticed.
+		cancel()
+	}
+
+	waitForGoroutines(t, baseline, 5*time.Second)
+}
+
+// TestCoordinator_Lifecycle_StopThenStart_Refuses is #84.
+//
+// Stop before Start burned the worker's start Once, so a subsequent Start brought
+// up the drain goroutine and the health poller while silently leaving the worker
+// dead.  The coordinator then looked healthy, Put returned nil, and nothing was
+// ever replicated for the rest of the process's life.  It is now an error.
+func TestCoordinator_Lifecycle_StopThenStart_Refuses(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+	c := New(primary, backup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.Stop() // e.g. a deferred Stop on a boot path that failed later
+
+	err := c.Start(ctx)
+	if err == nil {
+		t.Fatal("Start after Stop returned nil; the caller has no way to learn that " +
+			"replication is dead, which is the whole of #84")
+	}
+	if !errors.Is(err, ErrStopped) {
+		t.Errorf("Start after Stop: got %v, want an error wrapping ErrStopped", err)
+	}
+
+	// And the claim is accurate: the coordinator really is not replicating.  A Put
+	// still writes to the primary synchronously, so this asserts on the backup.
+	if err := c.Put(ctx, "k", []byte("v")); err != nil &&
+		!errors.Is(err, ErrReplicationNotQueued) {
+		t.Fatalf("Put: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if backupClient.hasKey("k") {
+		t.Error("backup received the object from a coordinator that refused to start")
+	}
+}
+
+// TestCoordinator_Lifecycle_StartIsIdempotent keeps the other half of the #84
+// contract honest: a second Start on a *running* coordinator must succeed and must
+// not launch a second set of background goroutines.
+func TestCoordinator_Lifecycle_StartIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(primary)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mustStart(t, ctx, c)
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("second Start on a running coordinator: got %v, want nil", err)
+	}
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("third Start on a running coordinator: got %v, want nil", err)
+	}
+
+	// A double Add on drainWg would make this Stop wait for a Done that never
+	// comes, and a double-launched drain would race the final flush.  Stop
+	// returning nil within its budget is the assertion.
+	if err := c.StopContext(context.Background()); err != nil {
+		t.Errorf("Stop after three Starts: %v — Start launched goroutines it did not "+
+			"account for", err)
+	}
+}
+
+// TestCoordinator_Lifecycle_StopBeforeStart_IsTerminalNotFatal records the
+// deliberate half of the #84 decision.  Stop-before-Start stays legal — a boot
+// path that defers Stop and then fails must not panic — but it is terminal, and
+// the terminality is what the previous test asserts.  Both halves are the contract.
+func TestCoordinator_Lifecycle_StopBeforeStart_IsTerminalNotFatal(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(primary)
+
+	done := make(chan struct{})
+	go func() {
+		c.Stop()
+		c.Stop() // idempotent
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop before Start did not return within 2s")
+	}
+}
+
+// TestCoordinator_SetWorkerQueueDepth_AfterStart_Refuses is #85.
+//
+// The setter unconditionally replaced c.worker.  Called on a running coordinator
+// it therefore orphaned the goroutine draining the live queue and installed a
+// fresh worker that nobody would ever Start: every later Enqueue filled a queue
+// with no consumer, Put kept returning nil, and replication was over.  The
+// coordinator's own ReplicationQueueDepth then reported the *new* worker's depth,
+// so the queue looked empty while jobs piled up in a channel nobody held.
+func TestCoordinator_SetWorkerQueueDepth_AfterStart_Refuses(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+	c := New(primary, backup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mustStart(t, ctx, c)
+	defer c.Stop()
+
+	// Prove replication works before the bad call, so a failure afterwards is
+	// attributable to the setter and not to a coordinator that never worked.
+	if err := c.Put(ctx, "before", []byte("v1")); err != nil {
+		t.Fatalf("Put(before): %v", err)
+	}
+	waitForKey(t, backupClient, "before", 2*time.Second)
+
+	err := c.SetWorkerQueueDepth(64)
+	if err == nil {
+		t.Fatal("SetWorkerQueueDepth after Start returned nil; it used to replace the " +
+			"running worker and end replication for the process lifetime (#85)")
+	}
+	if !errors.Is(err, ErrStarted) {
+		t.Errorf("SetWorkerQueueDepth after Start: got %v, want an error wrapping ErrStarted", err)
+	}
+
+	// The rejection has to be a no-op, not a partial mutation: replication must
+	// still work.  This is the assertion the old code failed.
+	if err := c.Put(ctx, "after", []byte("v2")); err != nil {
+		t.Fatalf("Put(after): %v", err)
+	}
+	waitForKey(t, backupClient, "after", 2*time.Second)
+}
+
+// TestCoordinator_GatedSetters_AfterStart_AllRefuse covers the rest of the frozen
+// configuration set in one place, so a newly added setter that forgets the gate is
+// noticed here rather than in production.
+func TestCoordinator_GatedSetters_AfterStart_AllRefuse(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(primary)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mustStart(t, ctx, c)
+	defer c.Stop()
+
+	calls := map[string]func() error{
+		"SetStore":              func() error { return c.SetStore(metadata.NewMemoryStore()) },
+		"SetLeaseManager":       func() error { return c.SetLeaseManager(lease.NewMemoryManager("x")) },
+		"SetMetrics":            func() error { return c.SetMetrics(metrics.New(prometheus.NewRegistry())) },
+		"SetHealthPollInterval": func() error { return c.SetHealthPollInterval(time.Second) },
+		"SetLeaseTTL":           func() error { return c.SetLeaseTTL(time.Second) },
+		"SetWorkerQueueDepth":   func() error { return c.SetWorkerQueueDepth(8) },
+	}
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil {
+				t.Fatalf("%s after Start: got nil, want an error wrapping ErrStarted", name)
+			}
+			if !errors.Is(err, ErrStarted) {
+				t.Errorf("%s after Start: got %v, want an error wrapping ErrStarted", name, err)
+			}
+		})
+	}
+}
+
+// TestCoordinator_DynamicSetters_AfterStart_StillApply is the negative control for
+// the gate.  These five knobs are genuinely dynamic — they are read per operation,
+// not copied into a goroutine at Start — so gating them would be a regression, not
+// a safety improvement.  The distinction is the whole design of the contract, so it
+// is asserted rather than left to the doc comment.
+func TestCoordinator_DynamicSetters_AfterStart_StillApply(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	c := New(primary)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mustStart(t, ctx, c)
+	defer c.Stop()
+
+	c.SetPolicy(policy.New())
+	c.SetCache(cache.New(cache.Config{MaxBytes: 1024}))
+	c.SetCircuitBreaker(circuitbreaker.New(3, time.Hour))
+	c.SetRetryConfig(&retry.Config{MaxAttempts: 2, InitialDelay: time.Millisecond, Multiplier: 1.0})
+	c.SetEnqueueBackpressure(10 * time.Millisecond)
+
+	// The cache is the one whose effect is directly observable: a Get populates
+	// it, so a second Get is served without touching the site.
+	if _, err := c.Get(ctx, "k"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, err := c.Get(ctx, "k"); err != nil {
+		t.Fatalf("cached Get: %v", err)
+	}
+}
+
+// TestCoordinator_SetMetrics_ConcurrentWithPut is #86.
+//
+// SetMetrics writes c.m under c.mu while Put, Get and the event drain read the
+// field with no lock at all.  It is a data race on an 8-byte pointer, which looks
+// harmless and is not: the reader can observe the write out of order, so the
+// `if c.m != nil` guard the old helpers relied on could pass while the value is
+// still the zero it was reading a moment ago.  -race is the assertion; the test
+// only has to create the overlap.
+//
+// The setter now refuses after Start, so the surviving window is the one that
+// remains legal: a caller configuring a *created* coordinator while another
+// goroutine uses it.  That is a real pattern (config assembly racing the first
+// request) and it is what this exercises.
+func TestCoordinator_SetMetrics_ConcurrentWithPut(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	backup, _ := makeMount("backup", types.SiteRoleBackup, nil)
+	c := New(primary, backup)
+	c.SetCache(cache.New(cache.Config{MaxBytes: 4096})) // makes Get touch the cache metrics
+	// No worker is running here — the coordinator is deliberately left in the
+	// created state, which is the window SetMetrics is still allowed in — so the
+	// replication queue fills and never drains.  A negative budget makes Put try
+	// once and report ErrReplicationNotQueued instead of waiting out the
+	// backpressure timer on every call, which would turn this into a 5-minute test.
+	c.SetEnqueueBackpressure(-1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const iterations = 100
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Each call gets its own registry: re-registering the same collectors
+			// would panic, which would mask the race this test is looking for.
+			if err := c.SetMetrics(metrics.New(prometheus.NewRegistry())); err != nil {
+				return // gated; nothing more to do
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Errors are expected and irrelevant: the point is that Put reads c.m.
+			_ = c.Put(ctx, fmt.Sprintf("key-%d", i), []byte("data"))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = c.Get(ctx, "k") // reads c.m via the cache hit/miss counters
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		// AddSite/RemoveSite reach c.m through metricsSiteCountLocked, which is the
+		// one read that happens with the write lock already held.
+		for i := 0; i < iterations; i++ {
+			name := fmt.Sprintf("extra-%d", i)
+			c.AddSite(makeMountOnly(name))
+			c.RemoveSite(name)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestCoordinator_ReplicationQueueDepth_ConcurrentWithSetWorkerQueueDepth is the
+// second half of #85: the unlocked read of the c.worker pointer.  Both of these
+// are exported, so this races two documented API calls against each other with
+// nothing exotic in between — and it failed under -race before workerRef existed.
+func TestCoordinator_ReplicationQueueDepth_ConcurrentWithSetWorkerQueueDepth(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	c := New(primary)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= 200; i++ {
+			_ = c.SetWorkerQueueDepth(i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = c.ReplicationQueueDepth()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestCoordinator_StopContext_BoundedWhenTransferWedged is #83 on the worker path.
+//
+// Stop waited on the replication worker without any bound, and the worker waits
+// for the in-flight transfer.  A destination site that never answers therefore held
+// SIGTERM open indefinitely: the daemon's shutdown path is `cancel(); c.Close()`,
+// and Close's wait is not on the ctx that was cancelled.  Operators saw the process
+// survive its grace period and get SIGKILLed, losing the in-memory queue.
+func TestCoordinator_StopContext_BoundedWhenTransferWedged(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := backupClient.blockPuts()
+	// Released only on the way out.  Releasing before StopContext would turn this
+	// into the settle-normally test; releasing in a defer that runs *after* the
+	// measurement is what leaves the transfer genuinely wedged, which is the shape
+	// #83 warns about — get it wrong and the test hangs instead of failing.
+	defer release()
+
+	c := New(primary, backup)
+	mustConfigure(t, c.SetStore(metadata.NewMemoryStore()))
+	mustStart(t, ctx, c)
+
+	if err := c.Put(ctx, "wedged.bam", []byte("genome")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	backupClient.waitForPut(t, 1, 2*time.Second)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer stopCancel()
+
+	start := time.Now()
+	err := c.StopContext(stopCtx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("StopContext returned nil while a transfer was wedged in the destination's Put")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("StopContext error: got %v, want a wrapped context.DeadlineExceeded", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("StopContext took %v with a 200ms budget — shutdown is not bounded, "+
+			"which is exactly the SIGTERM hang in #83", elapsed)
+	}
+}
+
+// TestCoordinator_Stop_CompletesWhenHealthProbeWedged is the other #83 path, and
+// the one that matters most in production because it needs no traffic at all.
+//
+// The health poller calls Health, which used to wg.Wait() for every probe.  objectfs
+// probes are not context-aware — ClientManager.HealthCheck takes a pooled client via
+// ConnectionPool.Get, which has a hard-coded 30 s timeout and no ctx parameter — so a
+// saturated pool pinned Health open, pinned the poller open, and pinned Stop open,
+// with an idle coordinator and no replication in flight.
+//
+// The assertion is that Stop *succeeds* quickly, not that it times out.  Both layers
+// of the fix are visible in that: Health returns its partial report as soon as its
+// context is cancelled, so cancelling the drain context is enough to retire the
+// poller, and StopContext's own budget is never reached.  A wedged probe now costs
+// one abandoned goroutine in a terminating process instead of the whole shutdown.
+// Bounding Stop alone would have got a *timeout* here, and a non-zero exit code on
+// every restart of a cluster with one slow endpoint.
+func TestCoordinator_Stop_CompletesWhenHealthProbeWedged(t *testing.T) {
+	t.Parallel()
+
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := primaryClient.blockHealth()
+	// Released only on the way out, so the probe is genuinely wedged for the whole
+	// of the measurement below.  Releasing it first is the mistake that turns this
+	// into a test that hangs rather than one that fails.
+	defer release()
+
+	c := New(primary)
+	mustConfigure(t, c.SetHealthPollInterval(10*time.Millisecond))
+	mustStart(t, ctx, c)
+
+	// The first poll happens immediately at Start, so this is the probe that wedges.
+	primaryClient.waitForHealth(t, 1, 2*time.Second)
+
+	// Stop runs on its own goroutine: on the pre-fix tree it never returns at all,
+	// and a test that fails is worth more than a test that hangs.
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		err := c.StopContext(context.Background())
+		done <- result{err, time.Since(start)}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Errorf("StopContext: %v — a wedged probe should be abandoned, not reported as "+
+				"a failed shutdown", r.err)
+		}
+		// defaultStopTimeout is 30 s, so anything near it means the bound fired
+		// rather than the poller retiring on its own.
+		if r.elapsed > 3*time.Second {
+			t.Errorf("StopContext took %v — the poller is not retiring on context "+
+				"cancellation, it is being timed out", r.elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("StopContext did not return within 10s while a health probe was wedged — " +
+			"this is the SIGTERM hang in #83")
+	}
+}
+
+// TestCoordinator_Health_ReportsTimedOutSitesAsUnknown pins the shape of the
+// partial report.  Health returns on its deadline, and every site that has not
+// answered is present in the map with ErrHealthTimeout — present, not omitted,
+// because SiteInfos and preferHealthySites both index the report by site name and
+// read a missing key as "healthy".
+func TestCoordinator_Health_ReportsTimedOutSitesAsUnknown(t *testing.T) {
+	t.Parallel()
+
+	fast, _ := makeMount("fast", types.SiteRolePrimary, nil)
+	slow, slowClient := makeMount("slow", types.SiteRoleBackup, nil)
+
+	release := slowClient.blockHealth()
+	defer release()
+
+	c := New(fast, slow)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	report := c.Health(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("Health took %v with a 150ms deadline — the deadline is a request, not a guarantee", elapsed)
+	}
+	if len(report) != 2 {
+		t.Fatalf("report has %d entries, want 2 (one per site); a missing key reads as healthy "+
+			"to preferHealthySites: %v", len(report), report)
+	}
+	if err := report["slow"]; !errors.Is(err, ErrHealthTimeout) {
+		t.Errorf("report[slow]: got %v, want an error wrapping ErrHealthTimeout", err)
+	}
+	if err := report["fast"]; err != nil {
+		t.Errorf("report[fast]: got %v, want nil — a fast site must not be tarred with the slow one", err)
+	}
+}
+
+// waitForKey polls a client for a key, failing the test if it never arrives.
+func waitForKey(t *testing.T, mc *memClient, key string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if mc.hasKey(key) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("key %q never replicated within %v", key, timeout)
+}
+
+// makeMountOnly is makeMount for tests that do not need the client handle.
+func makeMountOnly(name string) *site.SiteMount {
+	m, _ := makeMount(name, types.SiteRoleBackup, nil)
+	return m
 }

--- a/internal/replication/worker.go
+++ b/internal/replication/worker.go
@@ -10,9 +10,28 @@
 //
 // # Lifecycle
 //
+// A Worker is single-use.  It moves through exactly three states, in one
+// direction only:
+//
+//	created --Start--> running --Stop--> stopped
+//	created ---------------Stop--------> stopped
+//
 // Create a Worker with NewWorker, call Start to begin processing, then Stop
 // when done.  Enqueue is safe to call before Start; jobs accumulate in the
-// bounded queue.  Stop waits for the currently executing job to finish.
+// bounded queue.  Stop waits for the currently executing job to finish, and
+// StopContext bounds that wait.
+//
+// A stopped Worker cannot be restarted: Start on it is a no-op logged at Error,
+// and that includes a Worker stopped before it was ever started.  The single-use
+// rule is deliberate rather than an artefact — the done channel, the WaitGroup
+// and the job context are all one-shot — and it is the same rule the coordinator
+// enforces one level up, so a stopped Worker is never reached through it.
+//
+// Before this was a state machine the rule was expressed as two sync.Onces, and
+// Stop burned Start's once with `w.once.Do(func(){})`.  That made "stopped after
+// running" and "stopped before ever running" indistinguishable to the caller and
+// to the doc comment, which claimed Stop-before-Start was safe while it in fact
+// disabled the worker for the process lifetime with no way to observe it (#84).
 //
 // # Events
 //
@@ -92,18 +111,49 @@ const (
 	defaultBaseBackoff = 100 * time.Millisecond
 )
 
+// workerState is the Worker's position in its one-directional lifecycle.
+type workerState int
+
+const (
+	// workerCreated is a Worker that has never run.  Start moves it to
+	// workerRunning; Stop moves it straight to workerStopped.
+	workerCreated workerState = iota
+	// workerRunning is a Worker whose run goroutine is live.
+	workerRunning
+	// workerStopped is terminal.  Start on it is refused.
+	workerStopped
+)
+
+func (s workerState) String() string {
+	switch s {
+	case workerCreated:
+		return "created"
+	case workerRunning:
+		return "running"
+	case workerStopped:
+		return "stopped"
+	default:
+		return fmt.Sprintf("workerState(%d)", int(s))
+	}
+}
+
 // Worker processes ReplicationJobs from a bounded FIFO queue.
 //
 // Each job is attempted up to MaxRetries times with exponential backoff
 // (baseBackoff × 2^(attempt-1)).  Worker is safe for concurrent use.
+// See the package doc for the lifecycle contract.
 type Worker struct {
 	queue  chan ReplicationJob
 	events chan ReplicationEvent
 
-	wg        sync.WaitGroup
-	done      chan struct{}
-	once      sync.Once
-	closeOnce sync.Once
+	wg   sync.WaitGroup
+	done chan struct{}
+
+	// stateMu guards state.  It is held only across the state transition
+	// itself, never across wg.Wait, so a Stop in progress cannot block a
+	// concurrent Started query.
+	stateMu sync.Mutex
+	state   workerState
 
 	// baseBackoff controls the initial retry delay.  Defaults to
 	// defaultBaseBackoff; may be overridden in tests.
@@ -150,21 +200,95 @@ func (w *Worker) Enqueue(job ReplicationJob) error {
 	}
 }
 
-// Start launches the background worker goroutine.
-// Calling Start multiple times is safe; only the first call has effect.
-func (w *Worker) Start(ctx context.Context) {
-	w.once.Do(func() {
-		w.wg.Add(1)
-		go w.run(ctx)
-	})
+// Start launches the background worker goroutine and reports whether it did.
+//
+// Calling Start more than once is safe: the second call returns false and has no
+// effect.  Start on a stopped Worker also returns false, and logs at Error —
+// restarting a Worker is not supported (see the package Lifecycle doc), and a
+// caller that tries has almost certainly lost track of its own lifecycle.
+// [Coordinator.Start] turns that false into an error the operator can see rather
+// than running with replication silently off (#84).
+func (w *Worker) Start(ctx context.Context) bool {
+	w.stateMu.Lock()
+	switch w.state {
+	case workerRunning:
+		w.stateMu.Unlock()
+		return false
+	case workerStopped:
+		w.stateMu.Unlock()
+		slog.Error("replication: Start on a stopped worker; a Worker is single-use and cannot be restarted")
+		return false
+	}
+	w.state = workerRunning
+	w.wg.Add(1)
+	w.stateMu.Unlock()
+
+	go w.run(ctx)
+	return true
+}
+
+// Started reports whether the worker's run goroutine is currently live.
+func (w *Worker) Started() bool {
+	w.stateMu.Lock()
+	defer w.stateMu.Unlock()
+	return w.state == workerRunning
 }
 
 // Stop signals the worker to exit and waits for it to finish the current job.
-// Calling Stop before Start is safe.  Calling Stop multiple times is safe.
+//
+// Stop before Start is a genuine no-op on the goroutine — there is none — but it
+// is still terminal: it moves a created Worker to stopped, so a later Start is
+// refused.  Calling Stop more than once is safe.
+//
+// Stop waits without bound.  A job parked in an unresponsive site's PUT holds it
+// there for as long as that PUT takes, which is the shutdown hang in #83; prefer
+// [Worker.StopContext] anywhere a deadline matters.
 func (w *Worker) Stop() {
-	w.once.Do(func() {}) // prevent any future Start
-	w.closeOnce.Do(func() { close(w.done) })
-	w.wg.Wait()
+	_ = w.StopContext(context.Background())
+}
+
+// StopContext signals the worker to exit and waits up to ctx for the current job
+// to settle.  It returns nil once the run goroutine has returned, or ctx.Err() if
+// ctx ends first.
+//
+// The signal half always happens, even on the error return: the worker is
+// stopped, and the only thing the deadline gives up on is *observing* that it
+// finished.  A caller that gets a non-nil error must treat the in-flight job as
+// still running and its terminal event as possibly unemitted — the job is
+// abandoned rather than cancelled, because transfer holds the caller's context
+// and Stop has no authority to cancel it.
+//
+// Abandoning a goroutine is a deliberate trade.  A transfer blocked in a site's
+// PUT does not become interruptible because shutdown would like it to be, so the
+// options are a leaked goroutine in a process that is terminating anyway, or a
+// process that never terminates.  #83 chose the first.
+func (w *Worker) StopContext(ctx context.Context) error {
+	w.stateMu.Lock()
+	alreadyStopped := w.state == workerStopped
+	w.state = workerStopped
+	w.stateMu.Unlock()
+
+	if !alreadyStopped {
+		close(w.done)
+	}
+
+	// wg.Wait has no context-aware form, so it runs on its own goroutine and the
+	// select below picks whichever finishes first.  This goroutine outlives a
+	// timed-out StopContext by exactly as long as the abandoned job does.
+	waited := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(waited)
+	}()
+
+	select {
+	case <-waited:
+		return nil
+	case <-ctx.Done():
+		slog.Warn("replication: worker did not stop within the deadline; abandoning the in-flight job",
+			"error", ctx.Err())
+		return ctx.Err()
+	}
 }
 
 // ── Internal ─────────────────────────────────────────────────────────────────

--- a/internal/replication/worker_test.go
+++ b/internal/replication/worker_test.go
@@ -22,6 +22,12 @@ type failClient struct {
 	data    map[string][]byte
 	getErrs []error // consumed in order; nil = success
 	putErrs []error // consumed in order; nil = success
+	// putGate, if non-nil, blocks Put until it is closed.  It deliberately
+	// ignores the caller's context: a real S3 PUT parked in a connection pool or
+	// a TCP retransmit does not return because someone cancelled a context, and
+	// that is precisely the shutdown case StopContext has to bound (#83).
+	putGate     chan struct{}
+	putsEntered int
 }
 
 func newFailClient(objs map[string][]byte) *failClient {
@@ -51,6 +57,16 @@ func (f *failClient) Get(_ context.Context, key string, _, _ int64) ([]byte, err
 }
 
 func (f *failClient) Put(_ context.Context, key string, data []byte) error {
+	// The gate is read under the lock but waited on outside it: blocking while
+	// holding f.mu would deadlock any concurrent hasKey call.
+	f.mu.Lock()
+	gate := f.putGate
+	f.putsEntered++
+	f.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if len(f.putErrs) > 0 {
@@ -64,6 +80,34 @@ func (f *failClient) Put(_ context.Context, key string, data []byte) error {
 	copy(cp, data)
 	f.data[key] = cp
 	return nil
+}
+
+// blockPuts makes every subsequent Put on this client wait.  The returned
+// release is safe to call more than once.
+func (f *failClient) blockPuts() (release func()) {
+	gate := make(chan struct{})
+	f.mu.Lock()
+	f.putGate = gate
+	f.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
+}
+
+// waitForPut blocks until a Put has reached the gate, so a test that needs a
+// transfer to be genuinely in flight does not race the worker's scheduling.
+func (f *failClient) waitForPut(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		entered := f.putsEntered
+		f.mu.Unlock()
+		if entered >= 1 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("no Put reached the client within %v — the transfer never started", timeout)
 }
 
 func (f *failClient) Delete(_ context.Context, _ string) error { return nil }
@@ -390,6 +434,169 @@ func TestWorker_StopBeforeStart(t *testing.T) {
 	t.Parallel()
 	w := NewWorker(4)
 	w.Stop() // must not panic or deadlock
+}
+
+// ─── Lifecycle (#83, #84) ─────────────────────────────────────────────────────
+
+// TestWorker_Lifecycle_StateMachine pins the one-directional contract from the
+// package doc: Start once succeeds, Start again is a no-op, Stop is terminal, and
+// a stopped worker refuses to restart.
+func TestWorker_Lifecycle_StateMachine(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(4)
+	if w.Started() {
+		t.Error("Started() on a fresh worker: got true, want false")
+	}
+	if !w.Start(ctx) {
+		t.Fatal("Start on a created worker: got false, want true")
+	}
+	if !w.Started() {
+		t.Error("Started() after Start: got false, want true")
+	}
+	if w.Start(ctx) {
+		t.Error("second Start on a running worker: got true, want false (it must not launch a second goroutine)")
+	}
+
+	w.Stop()
+	if w.Started() {
+		t.Error("Started() after Stop: got true, want false")
+	}
+	w.Stop() // idempotent: must not panic on a double close of w.done
+	if w.Start(ctx) {
+		t.Error("Start on a stopped worker: got true, want false — a Worker is single-use")
+	}
+}
+
+// TestWorker_StopBeforeStart_IsTerminal is the worker half of #84.  Stop before
+// Start used to be implemented as w.once.Do(func(){}), burning Start's Once, so a
+// later Start silently did nothing and the caller had no way to find out.  The
+// worker is still single-use — that part was intended — but the refusal now has to
+// be observable, which is what lets Coordinator.Start turn it into an error.
+func TestWorker_StopBeforeStart_IsTerminal(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(4)
+	w.Stop()
+
+	if w.Start(ctx) {
+		t.Fatal("Start after a Stop-before-Start returned true, but the worker cannot run: " +
+			"a caller that trusts this reports success while replication is off for the process lifetime")
+	}
+
+	// And the refusal is real, not just a return value: nothing drains the queue.
+	src, _ := makeMount("src", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "k"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if dstClient.hasKey("k") {
+		t.Error("a job was transferred by a worker that refused to start")
+	}
+}
+
+// TestWorker_StopContext_BoundedWhenTransferWedged is the worker half of #83.
+// A PUT parked in an unresponsive endpoint must not be able to hold shutdown open:
+// StopContext returns when its budget expires and reports ctx.Err() so the caller
+// knows the job was abandoned rather than settled.
+func TestWorker_StopContext_BoundedWhenTransferWedged(t *testing.T) {
+	t.Parallel()
+
+	src, _ := makeMount("src", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := dstClient.blockPuts()
+	// Released before StopContext is measured would defeat the test; released in a
+	// defer so the abandoned goroutine still exits when the test ends.
+	defer release()
+
+	w := fastWorker(4)
+	if !w.Start(ctx) {
+		t.Fatal("Start: got false")
+	}
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "k"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	dstClient.waitForPut(t, 2*time.Second)
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer stopCancel()
+
+	start := time.Now()
+	err := w.StopContext(stopCtx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("StopContext returned nil while the transfer was still wedged in Put")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("StopContext error: got %v, want a wrapped context.DeadlineExceeded", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("StopContext took %v with a 100ms budget — the wait is not actually bounded", elapsed)
+	}
+
+	// The signal half must have happened regardless of the error: releasing the
+	// transfer lets the abandoned goroutine finish and exit rather than picking up
+	// another job.
+	if w.Started() {
+		t.Error("Started() after a timed-out StopContext: got true, want false")
+	}
+}
+
+// TestWorker_StopContext_ReturnsNilWhenSettled is the companion to the bounded
+// case: with room to finish, StopContext reports success rather than a timeout.
+func TestWorker_StopContext_ReturnsNilWhenSettled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fastWorker(4)
+	if !w.Start(ctx) {
+		t.Fatal("Start: got false")
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	if err := w.StopContext(stopCtx); err != nil {
+		t.Fatalf("StopContext on an idle worker: %v", err)
+	}
+}
+
+// TestWorker_Lifecycle_ConcurrentStartStop runs Start and Stop against each other
+// under -race.  Whichever wins, the invariant is the same: no goroutine survives
+// the Stop, and neither call panics on a double close of w.done.
+func TestWorker_Lifecycle_ConcurrentStartStop(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 50; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		w := fastWorker(4)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); w.Start(ctx) }()
+		go func() { defer wg.Done(); w.Stop() }()
+		wg.Wait()
+
+		// Stop is terminal either way, so the worker must be stopped when both
+		// calls have returned — even if Start ran second and observed "stopped".
+		if w.Started() {
+			t.Fatalf("iteration %d: worker still running after a concurrent Start/Stop", i)
+		}
+		cancel()
+	}
 }
 
 // TestWorker_MultipleJobs verifies that multiple queued jobs are all processed.


### PR DESCRIPTION
Six issues, all in the coordinator's lifecycle path, fixed as one redesign
rather than six patches — because five of them were the same missing invariant
and patching them independently would have produced three defensive workarounds
that still disagreed with each other.

## The lifecycle contract, and why

The coordinator had no lifecycle state. "Started" was inferred three different
ways — a `sync.Once`, whether `storeCancel` was nil, and whether a shared
`WaitGroup` was zero — none of which were ordered against `Stop`. So the first
decision was what the contract *is*, documented on the package and enforced by
the code:

**A Coordinator is single-use.** `created → running → stopped`, one direction,
never back.

| Rule | Enforcement |
|---|---|
| Start is idempotent, and reports failure | returns `error`; nil on the starting call and on later calls while running |
| Stop before Start is legal **and terminal** | moves `created → stopped`; a later Start returns `ErrStopped` |
| Stop-then-Start is illegal | refused with an error that says so |
| Start and Stop are mutually ordered | `lifecycleMu` around each in full |
| Configuration is frozen at Start | six gated setters return `ErrStarted`; five dynamic ones unchanged |
| Stop and Close are bounded | `StopContext` / `CloseContext`, 30 s default |

`replication.Worker` gets the same contract, for the same reason and at the
same granularity, so a stopped worker is never reachable through a running
coordinator.

Under this contract **#82 and #84 become invalid by construction** rather than
separately patched: there is no interleaving in which Stop can miss goroutines
Start is about to create, and no way for Stop-before-Start to leave a
coordinator that looks healthy but replicates nothing. #85 becomes a policy
question the contract answers.

## Per-issue

**#82 — Stop concurrent with Start leaked the drain and health goroutines**
(59/60 reproductions). Start must release `c.mu` across the lease acquisition
and `recoverPendingJobs`, both I/O; a Stop in that window saw `storeCancel` nil
and `storeWg` zero, concluded there was nothing to stop, and returned — after
which Start launched two goroutines under a context nobody would ever cancel.
Fixed with `lifecycleMu`. **`c.mu` deliberately cannot do this job**: it is the
lock every Get and Put takes, and holding it across a shutdown is exactly the
availability bug #95 is about. Ordering rule documented on the field:
`lifecycleMu` before `c.mu`, never the reverse.

**#83 — unbounded shutdown; SIGTERM never completed.** *I re-derived this
rather than trusting the issue body, and the conclusion is that both layers
needed fixing.* `SiteMount.Health` is a bare delegate, and the probe does
**not** honour its context: objectfs `Client.Health` → `Backend.HealthCheck` →
`ClientManager.HealthCheck` acquires a pooled client via `ConnectionPool.Get()`
*before* the ctx-aware `HeadBucket`, and `Get` is hard-coded to
`GetWithTimeout(30s)` taking no context at all (objectfs v0.12.0,
`internal/storage/s3/client.go:239-256`, `pool.go:111-201`). So `Health` now
returns a **partial report** — unanswered sites appear with `ErrHealthTimeout`,
present rather than omitted, keeping the key set equal to the site set as
`SiteInfos` and `preferHealthySites` assume — and every wait in
`StopContext`/`CloseContext`/`Worker.StopContext` is bounded.

Timed-out probes and transfers are **abandoned, not cancelled**, and every
results channel is buffered to its fan-out width so an abandoned goroutine
completes its send and exits instead of leaking on a blocked write. The trade
is explicit: a leaked goroutine in a process that is terminating anyway, or a
process that never terminates.

**#84 — Stop before Start permanently disabled replication, masked.** The
worker expressed single-use as two `sync.Once`s and Stop burned Start's with
`w.once.Do(func(){})`, making "stopped after running" and "never started"
indistinguishable. Now a state machine, and `Start` returns `bool` which the
coordinator turns into an operator-visible error.

**#85 — SetWorkerQueueDepth after Start orphaned the running worker.** Three
options: reconfigurable, documented no-op, or error. **Error is right, and not
because it is easiest**: the depth *is* a channel's buffer, and a channel's
buffer cannot be resized. "Reconfigurable" therefore means allocating a second
channel and then either discarding the jobs queued in the first or running one
worker against two queues — a real feature with semantics to design, not a
setter. A silent no-op is the status quo's mistake in a smaller size. The
second half of #85 was an unlocked `c.worker` read, now behind `workerRef()`.

**#86 — unsynchronized `c.m` read.** All reads go through `metrics()` under the
read lock, and the field is frozen at Start. The old `if c.m != nil` guards are
**deleted**, not kept: they were never load-bearing (every `*metrics.Metrics`
method is nil-safe) and were actively misleading, since an unsynchronized read
of a pointer-shaped field can observe a non-nil type word with a stale data
word — the guard passes and the call dereferences garbage.

**#95 — Close held `c.mu` across per-site network teardown.** Now follows the
snapshot-then-close-outside-the-lock pattern `RemoveSite` already uses (#80).
The site set is cleared *inside* the critical section, which both prevents a
concurrent request seeing a half-closed set and makes Close idempotent — tested,
because for a real client a double close is a double-free of its connection
pool. `c.ns` is replaced rather than closed, since it holds the same
`*SiteMount` pointers and closing both would close every site twice.

## #78 is not regressed

The teardown order is preserved (producer before consumer) and
`TestCoordinator_Stop_DrainFlushesBufferedEvents` still passes. The final flush
is now **conditional on the drain wait succeeding** — flushing alongside a live
drain would split the event buffer. `drainWg` and `healthWg` are split for the
same reason: a poller wedged in a context-ignoring probe must not veto the
flush of buffered replication events.

## Verified

- `go build ./...`, `go vet ./...`, `gofmt -l .` (empty)
- `go test -race -timeout=8m ./...` — all 15 packages ok
- `golangci-lint run --new-from-merge-base=main --max-same-issues=0 --max-issues-per-linter=0` — **0 issues**, re-run to convergence (the defaults truncate at 3 per class)
- timing-sensitive tests with `-count=5 -cpu=1,2,4`

**Every fix has a verified pre-fix reproduction**, obtained by reverting
behaviour *in place* with new symbols left declared (stashing the file yields
only compile errors, which proves nothing):

- **#82** `WARNING: DATA RACE` (Start read vs the `waitBounded` goroutine), then repeated `Stop did not complete within the default budget ... event drain did not exit ... health poller did not exit`, then `panic: test timed out after 3m0s`
- **#83** `StopContext did not return within 10s while a health probe was wedged`
- **#84** `Start after Stop returned nil; the caller has no way to learn that replication is dead`
- **#85** `WARNING: DATA RACE` (SetWorkerQueueDepth write vs workerRef read) + `SetWorkerQueueDepth after Start returned nil`
- **#86** `WARNING: DATA RACE` (SetMetrics write vs `metrics()` read via `Put`)
- **#95** `Sites() blocked while a site close was in flight ... so /health hangs for the duration`

The suite's gap was exactly here: nothing called `Stop()` against a busy
coordinator or any `Set*` after `Start()`, which is why five of these went
unnoticed. Leak assertions count goroutines by frame name and **poll rather
than sleep**; `runHealthPollLoop` became a named method so it has a stable
frame to match.

## Boundary: #83 is a genuine partial fix

`Close`/`Stop` are now bounded and correct **in themselves**, but the shipped
daemon still calls the unbounded form. `cmd/coordinator/main.go` is owned by
another agent and I did not touch it. It needs, at `main.go:303-307`:

```go
// Cancel the main context so the replication worker exits its loop, then stop
// the coordinator under a bound of its own.
cancel()
shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
defer shutdownCancel()
if err := c.CloseContext(shutdownCtx); err != nil {
    slog.Error("error closing coordinator", "error", err)
    exitCode = 1
}
```

The fresh context is **deliberately not derived from the already-cancelled root
`ctx`** — deriving it would abort the in-flight transfer instead of letting it
settle, which is the opposite of what #78 needs. Until that lands, `Close()`'s
own 30 s default applies, so the hang is bounded but the operator cannot tune
it.

**This PR also makes 13 whole-repo `errcheck` findings appear in
`cmd/coordinator` (118 → 131)**, because six setters and `Start` now return
errors that `main.go:133,137,143,159,235` and `api_test.go` ignore. The
blocking CI gate is `--new-from-merge-base` and is clean at **0**; the
whole-repo count is informational. These are not lint noise — an ignored
`SetWorkerQueueDepth` error in `main.go` is a real silent-misconfiguration
path, and it is the one place the new contract needs a caller-side change.

## What a reviewer should scrutinise

1. **The lock ordering** — `lifecycleMu` before `c.mu`, everywhere. This is the invariant holding #82 closed.
2. **Whether Stop-before-Start should be terminal.** I kept it terminal and made Start report it. The alternative (a true no-op leaving the coordinator startable) is defensible; it is a contract choice, not a bug fix, and it is the one decision here most worth a second opinion.
3. **#85's error-over-reconfigurable call**, and whether a resizable queue should be filed as a feature.
4. **Goroutine abandonment** in `Health` and both `StopContext`s — deliberate, with buffered channels sized so abandoned senders exit.
5. **The conditional flush** in `StopContext` — that it still satisfies #78 in the lost-lease and root-cancelled paths.
6. `TestCoordinator_Stop_CompletesWhenHealthProbeWedged` inverted its assertion during development: I expected Stop to hit its bound, and it correctly returns nil because a cancelled drain context retires the poller first. Worth confirming that reasoning.

Refs #82, #83, #84, #85, #86, #95
