### PR TITLE
fix: read-path correctness — cache invalidation races and breaker probe leaks (#89, #90, #94)

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -10,6 +10,21 @@
 // When a TTL is configured, expired entries are treated as cache misses on
 // Get; they are lazily removed from the index at that point rather than by a
 // background sweep.
+//
+// # Invalidation generation
+//
+// A read-through fill is not atomic with the read it caches: the caller takes a
+// miss, fetches from a remote site, and inserts the bytes some time later.  A
+// write or delete that lands in that window used to be lost — [Delete] removed
+// an entry that was not there yet, and the in-flight fill then inserted the
+// pre-write bytes, which had no expiry and so were served until LRU pressure
+// happened to evict them (#89, #90).
+//
+// Every invalidation therefore bumps a counter.  Callers doing a read-through
+// fill read it with [Cache.Generation] *before* the remote read and insert with
+// [Cache.PutIfUnchanged], which drops the value if the counter moved.  The
+// counter is global rather than per-key: an unrelated key's invalidation costs a
+// spurious skip, and a skipped fill is only a cache miss, which is always safe.
 package cache
 
 import (
@@ -59,6 +74,11 @@ type Cache struct {
 	misses   int64
 	evicted  int64
 	curBytes int64
+	// gen counts invalidations (Delete and Invalidate).  It is the whole of the
+	// generation mechanism described in the package doc: it never decreases, so
+	// "unchanged" is a plain equality test and there is nothing to garbage
+	// collect when a key stops being read (#89, #90).
+	gen uint64
 }
 
 // New creates a Cache with the supplied Config.
@@ -110,38 +130,7 @@ func (c *Cache) Get(key string) ([]byte, bool) {
 func (c *Cache) Put(key string, data []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	newSize := int64(len(data))
-
-	// Drop entries that can never fit within the byte budget.
-	if c.cfg.MaxBytes > 0 && newSize > c.cfg.MaxBytes {
-		return
-	}
-
-	// Replace existing entry: remove old bytes first.
-	if el, ok := c.index[key]; ok {
-		c.removeElement(el)
-	}
-
-	// Evict LRU entries until there is room for the new value.
-	if c.cfg.MaxBytes > 0 {
-		for c.curBytes+newSize > c.cfg.MaxBytes && c.list.Len() > 0 {
-			c.evictLRU()
-		}
-	}
-
-	e := &entry{
-		key:  key,
-		data: make([]byte, len(data)),
-	}
-	copy(e.data, data)
-	if c.cfg.TTL > 0 {
-		e.expiresAt = time.Now().Add(c.cfg.TTL)
-	}
-
-	el := c.list.PushFront(e)
-	c.index[key] = el
-	c.curBytes += newSize
+	c.putLocked(key, data)
 }
 
 // PutAndRecordEvictions inserts or replaces the value for key, exactly like
@@ -152,45 +141,52 @@ func (c *Cache) Put(key string, data []byte) {
 func (c *Cache) PutAndRecordEvictions(key string, data []byte) int64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.putLocked(key, data)
+}
 
-	newSize := int64(len(data))
+// Generation returns the current invalidation counter.
+//
+// Pair it with [PutIfUnchanged] to make a read-through fill safe against a
+// concurrent write or delete; see the package doc for why the counter is global.
+func (c *Cache) Generation() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gen
+}
 
-	if c.cfg.MaxBytes > 0 && newSize > c.cfg.MaxBytes {
-		return 0
+// PutIfUnchanged inserts or replaces the value for key only if no invalidation
+// has happened since gen was read, and reports whether it stored the value along
+// with the number of entries evicted to make room (as [PutAndRecordEvictions]
+// does).
+//
+// stored=false means an invalidation raced the fill and the value the caller
+// holds may predate it, so caching it could serve overwritten or deleted bytes
+// indefinitely — the cache has no expiry unless a TTL is configured (#89, #90).
+// Dropping it costs one cache miss on the next read.
+//
+// The comparison and the insert happen under the same lock acquisition, which is
+// what makes this a fix rather than a narrower window: an invalidation cannot
+// land between the caller's check and its write.
+func (c *Cache) PutIfUnchanged(key string, data []byte, gen uint64) (evicted int64, stored bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.gen != gen {
+		return 0, false
 	}
-
-	if el, ok := c.index[key]; ok {
-		c.removeElement(el)
-	}
-
-	var evicted int64
-	if c.cfg.MaxBytes > 0 {
-		for c.curBytes+newSize > c.cfg.MaxBytes && c.list.Len() > 0 {
-			c.evictLRU()
-			evicted++
-		}
-	}
-
-	e := &entry{
-		key:  key,
-		data: make([]byte, len(data)),
-	}
-	copy(e.data, data)
-	if c.cfg.TTL > 0 {
-		e.expiresAt = time.Now().Add(c.cfg.TTL)
-	}
-
-	el := c.list.PushFront(e)
-	c.index[key] = el
-	c.curBytes += newSize
-	return evicted
+	return c.putLocked(key, data), true
 }
 
 // Delete removes the entry for key if it exists.
+//
+// The invalidation generation is bumped whether or not the key was present: the
+// case that matters is precisely the one where it is absent because a
+// read-through fill for it is still in flight (#89, #90).
 func (c *Cache) Delete(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.gen++
 	if el, ok := c.index[key]; ok {
 		c.removeElement(el)
 	}
@@ -198,9 +194,14 @@ func (c *Cache) Delete(key string) {
 
 // Invalidate removes all entries whose key begins with prefix.
 // Pass an empty prefix to remove all entries.
+//
+// Bumps the invalidation generation, so in-flight read-through fills for any key
+// are dropped rather than reinstating a value this call was meant to remove.
 func (c *Cache) Invalidate(prefix string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	c.gen++
 
 	if prefix == "" {
 		// Fast path: clear everything.
@@ -243,6 +244,49 @@ func (c *Cache) Len() int {
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+// putLocked inserts or replaces the value for key and returns the number of
+// entries evicted to make room.  Caller must hold c.mu.
+//
+// The three exported insert paths share this so their eviction, byte-accounting,
+// and TTL behaviour cannot drift apart; PutAndRecordEvictions was previously a
+// hand-copied duplicate of Put.
+func (c *Cache) putLocked(key string, data []byte) int64 {
+	newSize := int64(len(data))
+
+	// Drop entries that can never fit within the byte budget.
+	if c.cfg.MaxBytes > 0 && newSize > c.cfg.MaxBytes {
+		return 0
+	}
+
+	// Replace existing entry: remove old bytes first.
+	if el, ok := c.index[key]; ok {
+		c.removeElement(el)
+	}
+
+	// Evict LRU entries until there is room for the new value.
+	var evicted int64
+	if c.cfg.MaxBytes > 0 {
+		for c.curBytes+newSize > c.cfg.MaxBytes && c.list.Len() > 0 {
+			c.evictLRU()
+			evicted++
+		}
+	}
+
+	e := &entry{
+		key:  key,
+		data: make([]byte, len(data)),
+	}
+	copy(e.data, data)
+	if c.cfg.TTL > 0 {
+		e.expiresAt = time.Now().Add(c.cfg.TTL)
+	}
+
+	el := c.list.PushFront(e)
+	c.index[key] = el
+	c.curBytes += newSize
+	return evicted
+}
 
 // removeElement removes el from the list and index, updating curBytes.
 // Caller must hold c.mu.

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -387,5 +388,189 @@ func TestCache_PutAndRecordEvictions_ConsistentWithPut(t *testing.T) {
 	}
 	if c1.Len() != c2.Len() {
 		t.Errorf("len differs: c1=%d c2=%d", c1.Len(), c2.Len())
+	}
+}
+
+// ── Invalidation generation (#89, #90) ────────────────────────────────────────
+//
+// These cover the mechanism.  The races it exists to fix are exercised
+// end-to-end, against a site whose Get blocks, in internal/coordinator.
+
+// TestCache_Generation_UnchangedByReadsAndFills verifies that only invalidation
+// moves the counter.  If ordinary traffic bumped it, every read-through fill
+// under concurrent load would be dropped and the cache would never populate.
+func TestCache_Generation_UnchangedByReadsAndFills(t *testing.T) {
+	t.Parallel()
+	c := New(Config{})
+	gen := c.Generation()
+
+	c.Put("a", []byte("A"))
+	c.Get("a")
+	c.Get("absent")
+	c.PutAndRecordEvictions("b", []byte("B"))
+
+	if got := c.Generation(); got != gen {
+		t.Errorf("generation moved without an invalidation: %d → %d", gen, got)
+	}
+}
+
+// TestCache_Generation_BumpedByDeleteOfAbsentKey is the case the whole fix turns
+// on.  A Delete that finds nothing still has to invalidate, because "nothing to
+// remove" is exactly what a concurrent read-through fill looks like from here:
+// the entry does not exist yet (#89, #90).
+func TestCache_Generation_BumpedByDeleteOfAbsentKey(t *testing.T) {
+	t.Parallel()
+	c := New(Config{})
+	gen := c.Generation()
+
+	c.Delete("never-cached")
+
+	if got := c.Generation(); got == gen {
+		t.Error("Delete of an absent key did not bump the generation; an in-flight " +
+			"fill for that key would be allowed to reinstate the deleted value")
+	}
+}
+
+// TestCache_Generation_BumpedByInvalidate verifies prefix and whole-cache
+// invalidation both move the counter.
+func TestCache_Generation_BumpedByInvalidate(t *testing.T) {
+	t.Parallel()
+	c := New(Config{})
+
+	gen := c.Generation()
+	c.Invalidate("prefix/")
+	afterPrefix := c.Generation()
+	if afterPrefix == gen {
+		t.Error("Invalidate(prefix) did not bump the generation")
+	}
+
+	c.Invalidate("")
+	if c.Generation() == afterPrefix {
+		t.Error(`Invalidate("") did not bump the generation`)
+	}
+}
+
+// TestCache_PutIfUnchanged_StoresWhenGenerationHolds verifies the happy path: an
+// uncontended fill still populates the cache.  Everything else here asserts a
+// refusal, so without this the mechanism could be inert and look correct.
+func TestCache_PutIfUnchanged_StoresWhenGenerationHolds(t *testing.T) {
+	t.Parallel()
+	c := New(Config{MaxBytes: 100})
+
+	gen := c.Generation()
+	if _, stored := c.PutIfUnchanged("k", []byte("v"), gen); !stored {
+		t.Fatal("PutIfUnchanged refused an uncontended fill")
+	}
+	data, ok := c.Get("k")
+	if !ok || string(data) != "v" {
+		t.Errorf(`after an accepted fill: got (%q, %v), want ("v", true)`, data, ok)
+	}
+}
+
+// TestCache_PutIfUnchanged_DropsAfterDelete is the #90 post-condition at the
+// cache layer: a fill holding pre-delete bytes must not resurrect them.
+func TestCache_PutIfUnchanged_DropsAfterDelete(t *testing.T) {
+	t.Parallel()
+	c := New(Config{MaxBytes: 100})
+
+	// A reader takes a miss and starts reading "SENSITIVE" from a site...
+	gen := c.Generation()
+	// ...a deleter removes the object from every site and invalidates...
+	c.Delete("k")
+	// ...and only then does the reader get around to filling.
+	if _, stored := c.PutIfUnchanged("k", []byte("SENSITIVE"), gen); stored {
+		t.Error("PutIfUnchanged stored a value invalidated by a concurrent Delete")
+	}
+	if _, ok := c.Get("k"); ok {
+		t.Error("deleted key is readable from the cache: the delete did not make " +
+			"the object unreadable (#90)")
+	}
+}
+
+// TestCache_PutIfUnchanged_DropsAfterInvalidate verifies a prefix invalidation
+// also fences in-flight fills.
+func TestCache_PutIfUnchanged_DropsAfterInvalidate(t *testing.T) {
+	t.Parallel()
+	c := New(Config{MaxBytes: 100})
+
+	gen := c.Generation()
+	c.Invalidate("")
+	if _, stored := c.PutIfUnchanged("k", []byte("v"), gen); stored {
+		t.Error("PutIfUnchanged stored a value invalidated by a concurrent Invalidate")
+	}
+}
+
+// TestCache_PutIfUnchanged_LeavesNewerValueIntact is the #89 shape specifically:
+// the loser of the race must not overwrite the winner.  A dropped fill costs a
+// cache miss; a fill that clobbers a fresh entry is silent staleness with no
+// expiry to bound it, because TTL defaults to 0.
+func TestCache_PutIfUnchanged_LeavesNewerValueIntact(t *testing.T) {
+	t.Parallel()
+	c := New(Config{MaxBytes: 100})
+
+	gen := c.Generation()    // reader observes the generation, then reads "v1"
+	c.Delete("k")            // writer commits "v2" at the sites and invalidates
+	c.Put("k", []byte("v2")) // a later read caches the new value
+
+	if _, stored := c.PutIfUnchanged("k", []byte("v1"), gen); stored {
+		t.Fatal("the stale fill was accepted")
+	}
+	data, ok := c.Get("k")
+	if !ok || string(data) != "v2" {
+		t.Errorf(`stale fill clobbered the current value: got (%q, %v), want ("v2", true)`, data, ok)
+	}
+}
+
+// TestCache_PutIfUnchanged_EvictionsMatchPut verifies the conditional path
+// reports evictions the way PutAndRecordEvictions does — the coordinator feeds
+// that count straight to a metric, one increment per eviction.
+func TestCache_PutIfUnchanged_EvictionsMatchPut(t *testing.T) {
+	t.Parallel()
+	// Budget = 10 bytes; two 5-byte entries fill it exactly, so a third evicts one.
+	c := New(Config{MaxBytes: 10})
+	c.Put("a", []byte("AAAAA"))
+	c.Put("b", []byte("BBBBB"))
+
+	evicted, stored := c.PutIfUnchanged("c", []byte("CCCCC"), c.Generation())
+	if !stored {
+		t.Fatal("fill refused")
+	}
+	if evicted != 1 {
+		t.Errorf("expected 1 eviction, got %d", evicted)
+	}
+}
+
+// TestCache_PutIfUnchanged_ConcurrentDeleteNeverResurrects hammers the
+// fill/invalidate interleaving under -race.  The assertion is the invariant
+// rather than a count of who won: however each round lands, a key must not be
+// readable after a Delete that followed the generation read.
+func TestCache_PutIfUnchanged_ConcurrentDeleteNeverResurrects(t *testing.T) {
+	t.Parallel()
+	c := New(Config{MaxBytes: 1024})
+
+	for round := 0; round < 200; round++ {
+		key := fmt.Sprintf("k%d", round)
+		gen := c.Generation()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		// The filler holds bytes it read before the delete.
+		go func() {
+			defer wg.Done()
+			c.PutIfUnchanged(key, []byte("stale"), gen)
+		}()
+		go func() {
+			defer wg.Done()
+			c.Delete(key)
+		}()
+		wg.Wait()
+
+		// The Delete happened after gen was read, so the fill must have lost —
+		// either refused outright, or removed by the Delete if it won the lock
+		// first.  Both orders are correct; a readable key is not.
+		if _, ok := c.Get(key); ok {
+			t.Fatalf("round %d: %q is cached after a Delete that followed the "+
+				"generation read", round, key)
+		}
 	}
 }

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -68,6 +68,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"iter"
 	"log/slog"
 	"sync"
 	"time"
@@ -1262,14 +1263,14 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 
 	healthReport, _ := c.HealthStatus()
 	ordered = preferHealthySites(ordered, healthReport)
-	ordered = filterByCircuitBreaker(cb, ordered)
+	ordered, cbBypass := filterByCircuitBreaker(cb, ordered)
 
 	var lastErr error
 	// allNotFound stays true while every site tried has answered "no such key".
 	// It distinguishes "the object does not exist" from "no site could answer",
 	// which the API layer needs to tell a 404 from a 502 (#77).
 	allNotFound := true
-	for _, s := range ordered {
+	for s := range attemptableSites(cb, ordered, cbBypass) {
 		var data []byte
 		siteErr := doWithRetry(ctx, retryCfg, func() error {
 			var err error
@@ -1537,6 +1538,24 @@ func (c *Coordinator) Delete(ctx context.Context, key string) error {
 // rules, health state, and breaker state all apply consistently to List —
 // the same way they do for Get and Head.
 // Pass limit ≤ 0 to retrieve all matching objects.
+//
+// # Circuit breaker
+//
+// List reads breaker state but never acquires a probe permit, and records no
+// outcomes.  It is a pure consumer of the state Get, Head, Put and Delete
+// maintain.  That is deliberate rather than an omission (#94):
+//
+//   - It cannot leak permits, which is what it used to do worst of all the read
+//     paths — it asked Allow for every candidate and then handed the whole set to
+//     the Namespace merge, recording nothing for any of them.
+//   - It could not reliably record them either.  [namespace.Namespace.List] folds
+//     per-site failures into one joined error for the merge, so List cannot
+//     attribute an outcome back to the site it came from without reimplementing
+//     the merge.
+//   - A HalfOpen site therefore stays listable while its probe is outstanding.
+//     Including it can only add keys to a merged listing that already tolerates
+//     unreachable sites, whereas excluding it silently truncates the namespace —
+//     the failure mode List must not have.
 func (c *Coordinator) List(ctx context.Context, prefix string, limit int) ([]objectfstypes.ObjectInfo, error) {
 	c.mu.RLock()
 	snapshot, pol, cb := c.snapshotSites(), c.policy, c.cb
@@ -1551,7 +1570,7 @@ func (c *Coordinator) List(ctx context.Context, prefix string, limit int) ([]obj
 
 	healthReport, _ := c.HealthStatus()
 	routed = preferHealthySites(routed, healthReport)
-	routed = filterByCircuitBreaker(cb, routed)
+	routed, _ = filterByCircuitBreaker(cb, routed)
 
 	// Merge from the policy-selected sites only.
 	ns := namespace.New(routed...)
@@ -1579,11 +1598,14 @@ func (c *Coordinator) Head(ctx context.Context, key string) (*objectfstypes.Obje
 
 	healthReport, _ := c.HealthStatus()
 	ordered = preferHealthySites(ordered, healthReport)
-	ordered = filterByCircuitBreaker(cb, ordered)
+	ordered, cbBypass := filterByCircuitBreaker(cb, ordered)
 
 	var lastErr error
 	allNotFound := true
-	for _, s := range ordered {
+	// Lazy permit acquisition, paired one-to-one with recordSiteResult below.  Head
+	// has the same first-hit-wins shape as Get and leaked probe permits the same
+	// way (#94).
+	for s := range attemptableSites(cb, ordered, cbBypass) {
 		var info *objectfstypes.ObjectInfo
 		siteErr := doWithRetry(ctx, retryCfg, func() error {
 			var err error
@@ -1763,26 +1785,100 @@ func doWithRetry(ctx context.Context, cfg *retry.Config, fn func() error) error 
 }
 
 // filterByCircuitBreaker returns a filtered subset of sites whose circuits
-// are not open.  For HalfOpen sites, Allow is called which marks them as
-// probing so only one probe is in flight at a time.
+// are not open, and whether the breaker is being bypassed for that subset.
 //
-// If cb is nil, or if every site's circuit is open, the original slice is
-// returned unchanged so callers are never completely blocked by stale state.
-func filterByCircuitBreaker(cb *circuitbreaker.Breaker, sites []*site.SiteMount) []*site.SiteMount {
+// bypass is true when cb is nil, or when every site's circuit is open — in which
+// case the original slice is returned unchanged so callers are never completely
+// blocked by stale state.  That fallback is load-bearing: without it a window in
+// which every site had failed once would be a total read outage no recovery could
+// clear, because a site that is never tried never records the success that would
+// close its circuit.  Callers must not ask the breaker for permission when bypass
+// is set; the sites in the returned slice have already been judged unusable and
+// asking would refuse every one of them.
+//
+// The membership test is [circuitbreaker.Breaker.State], not Allow.  Allow is not
+// a predicate — on a HalfOpen circuit it *takes* the single probe permit, which
+// only a recorded outcome releases.  Asking it about every candidate while the
+// read paths use just the first site that answers leaked one permit per unused
+// site and ejected those sites from routing for the process lifetime, reporting
+// HalfOpen so they did not even look tripped (#94).  State answers the same
+// routing question and takes nothing; the permit is now acquired per attempt, in
+// the read loops, where it is paired with a recordSiteResult that releases it.
+func filterByCircuitBreaker(cb *circuitbreaker.Breaker, sites []*site.SiteMount) (allowed []*site.SiteMount, bypass bool) {
 	if cb == nil {
-		return sites
+		return sites, true
 	}
-	allowed := make([]*site.SiteMount, 0, len(sites))
+	allowed = make([]*site.SiteMount, 0, len(sites))
 	for _, s := range sites {
-		if cb.Allow(s.Name()) {
+		if cb.State(s.Name()) != circuitbreaker.StateOpen {
 			allowed = append(allowed, s)
 		}
 	}
 	if len(allowed) == 0 {
 		// All circuits open — fall back to all sites to avoid blocking callers.
-		return sites
+		return sites, true
 	}
-	return allowed
+	return allowed, false
+}
+
+// attemptableSites yields the sites a first-hit-wins read may try, in order,
+// having acquired each one's circuit-breaker probe permit as it is yielded.
+//
+// The caller must call [recordSiteResult] exactly once for every site it
+// receives, and must not skip a yielded site for any other reason.  That pairing
+// is what releases the permit and is the whole of the fix for #94: acquiring
+// permits for the whole candidate list up-front, as filterByCircuitBreaker used
+// to, stranded one for every site the read did not reach — and a stranded
+// HalfOpen permit is never released, so the site was excluded from routing for
+// the process lifetime while reporting HalfOpen rather than Open.
+//
+// Breaking out of the range (which every successful read does) simply stops the
+// iteration; no permit is taken for a site that is never yielded.
+//
+// bypass comes from filterByCircuitBreaker and means "do not consult the
+// breaker": either there is none, or every circuit was open and the caller is
+// deliberately ignoring them.
+//
+// If the breaker refuses every candidate, the sites are yielded a second time
+// with no permit required.  This is the lazy equivalent of
+// filterByCircuitBreaker's all-open fallback, and it is needed because the two
+// decisions are no longer simultaneous: a site that was non-Open when the
+// candidate list was built can refuse the attempt a moment later, and without the
+// second pass a read that reached no site at all would report the object as
+// absent — a 404 for data that exists.  Recording an outcome for a site whose
+// permit we did not hold can release a concurrent probe early, which the old
+// all-open fallback also did; the outcome is real evidence about the site either
+// way, and the alternative is worse.
+func attemptableSites(cb *circuitbreaker.Breaker, sites []*site.SiteMount, bypass bool) iter.Seq[*site.SiteMount] {
+	return func(yield func(*site.SiteMount) bool) {
+		if bypass {
+			for _, s := range sites {
+				if !yield(s) {
+					return
+				}
+			}
+			return
+		}
+
+		attempted := 0
+		for _, s := range sites {
+			if !cb.Allow(s.Name()) {
+				continue
+			}
+			attempted++
+			if !yield(s) {
+				return
+			}
+		}
+		if attempted > 0 {
+			return
+		}
+		for _, s := range sites {
+			if !yield(s) {
+				return
+			}
+		}
+	}
 }
 
 // partitionByRole splits sites into primary-role and non-primary slices,

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -1236,6 +1236,12 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 	c.mu.RUnlock()
 
 	// Cache read-through: serve from cache when available.
+	//
+	// cacheGen is the invalidation generation observed *before* the site read, and
+	// is what the fill below is conditioned on.  It has to be captured here, not
+	// next to the fill: the whole point is to notice a Put or Delete that landed
+	// while this goroutine was blocked in s.Get (#89, #90).
+	var cacheGen uint64
 	if oc != nil {
 		if cached, ok := oc.Get(key); ok {
 			c.metricsCacheHit()
@@ -1243,6 +1249,7 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 			return cached, nil
 		}
 		c.metricsCacheMiss()
+		cacheGen = oc.Generation()
 	}
 
 	ordered, err := pol.Route(policy.OperationRead, key, snapshot)
@@ -1274,12 +1281,20 @@ func (c *Coordinator) Get(ctx context.Context, key string) ([]byte, error) {
 			allNotFound = false
 		}
 		if siteErr == nil {
-			// Populate cache on successful site fetch.
+			// Populate the cache on a successful site fetch — but only if nothing
+			// was invalidated while the read was in flight.  A Put or Delete that
+			// committed at the sites and then cleared the cache found nothing to
+			// clear, because this entry did not exist yet, so an unconditional fill
+			// reinstated bytes the caller had already overwritten or erased, with no
+			// expiry to bound how long they were served (#89, #90).  Skipping the
+			// fill costs one cache miss on the next read, which is always safe.
 			if oc != nil {
-				evicted := oc.PutAndRecordEvictions(key, data)
-				c.metricsCacheBytes(oc.Stats().Bytes)
-				for i := int64(0); i < evicted; i++ {
-					c.metricsCacheEviction()
+				evicted, stored := oc.PutIfUnchanged(key, data, cacheGen)
+				if stored {
+					c.metricsCacheBytes(oc.Stats().Bytes)
+					for i := int64(0); i < evicted; i++ {
+						c.metricsCacheEviction()
+					}
 				}
 			}
 			return data, nil

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -2180,9 +2180,12 @@ func TestFilterByCircuitBreaker_AllowsClosedSites(t *testing.T) {
 	s2, _ := makeMount("b", types.SiteRoleBackup, nil)
 	cb := circuitbreaker.New(1, time.Hour)
 
-	got := filterByCircuitBreaker(cb, []*site.SiteMount{s1, s2})
+	got, bypass := filterByCircuitBreaker(cb, []*site.SiteMount{s1, s2})
 	if len(got) != 2 {
 		t.Errorf("expected 2 sites, got %d", len(got))
+	}
+	if bypass {
+		t.Error("all circuits closed: breaker should not be bypassed")
 	}
 }
 
@@ -2196,9 +2199,12 @@ func TestFilterByCircuitBreaker_FiltersOpenCircuit(t *testing.T) {
 	cb := circuitbreaker.New(1, time.Hour)
 	cb.RecordFailure("a") // open circuit for "a"
 
-	got := filterByCircuitBreaker(cb, []*site.SiteMount{s1, s2})
+	got, bypass := filterByCircuitBreaker(cb, []*site.SiteMount{s1, s2})
 	if len(got) != 1 || got[0].Name() != "b" {
 		t.Errorf("expected only site-b, got %v", siteNames(got))
+	}
+	if bypass {
+		t.Error("one usable circuit remains: breaker should not be bypassed")
 	}
 }
 
@@ -2213,9 +2219,15 @@ func TestFilterByCircuitBreaker_FallbackWhenAllOpen(t *testing.T) {
 	cb.RecordFailure("a")
 	cb.RecordFailure("b")
 
-	got := filterByCircuitBreaker(cb, []*site.SiteMount{s1, s2})
+	got, bypass := filterByCircuitBreaker(cb, []*site.SiteMount{s1, s2})
 	if len(got) != 2 {
 		t.Errorf("all-open fallback: expected 2 sites, got %d", len(got))
+	}
+	// The read loops must be told to stop consulting the breaker for this set,
+	// or they would ask permission of the very circuits it just judged unusable
+	// and attempt nothing at all (#94).
+	if !bypass {
+		t.Error("all-open fallback: expected bypass=true")
 	}
 }
 
@@ -2225,9 +2237,12 @@ func TestFilterByCircuitBreaker_NilBreakerPassesThrough(t *testing.T) {
 	t.Parallel()
 
 	s1, _ := makeMount("a", types.SiteRolePrimary, nil)
-	got := filterByCircuitBreaker(nil, []*site.SiteMount{s1})
+	got, bypass := filterByCircuitBreaker(nil, []*site.SiteMount{s1})
 	if len(got) != 1 {
 		t.Errorf("nil cb: expected 1 site, got %d", len(got))
+	}
+	if !bypass {
+		t.Error("nil cb: expected bypass=true so callers skip the breaker entirely")
 	}
 }
 
@@ -3863,5 +3878,307 @@ func TestCoordinator_Get_ConcurrentWritesNeverLeaveStaleCache(t *testing.T) {
 	if string(data) != final {
 		t.Errorf("final Get returned %q, want %q: a read-through fill outlived a "+
 			"later write, and with TTL defaulting to 0 nothing ages it out (#89)", data, final)
+	}
+}
+
+// ─── Circuit-breaker probe permits (#94) ───────────────────────────────────────
+//
+// Allow is a permit acquisition, not a predicate: on a HalfOpen circuit it takes
+// the single probe permit, which only a recorded outcome releases.  Asking it
+// about every candidate while the read paths use only the first site that answers
+// stranded a permit per unused site, and a stranded permit is never released — the
+// site was ejected from routing for the process lifetime while reporting HalfOpen,
+// so it did not even look tripped.
+
+// halfOpenBreaker returns a breaker in which name is Open with the cooldown
+// already elapsed, i.e. the next Allow would transition it to HalfOpen and take
+// its probe.  Built with a zero cooldown rather than a sleep so the test is not
+// timing-dependent.
+func halfOpenBreaker(name string) *circuitbreaker.Breaker {
+	cb := circuitbreaker.New(1, 0)
+	cb.RecordFailure(name) // → Open, cooldown 0, so immediately probe-eligible
+	return cb
+}
+
+// TestCoordinator_Get_UnusedSiteKeepsItsProbePermit is the #94 acceptance test.
+//
+// An earlier site answers, so a later site whose circuit is probe-eligible is
+// never read.  Its permit must still be available afterwards.  Before the fix the
+// up-front Allow consumed it, nothing recorded an outcome, and the site was
+// unroutable from then on.
+func TestCoordinator_Get_UnusedSiteKeepsItsProbePermit(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("from-primary"),
+	})
+	backup, _ := makeMount("backup", types.SiteRoleBackup, map[string][]byte{
+		"k": []byte("from-backup"),
+	})
+
+	cb := halfOpenBreaker("backup")
+	c := New(primary, backup)
+	c.SetCircuitBreaker(cb)
+	ctx := context.Background()
+
+	data, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(data) != "from-primary" {
+		t.Fatalf("precondition: expected the primary to answer, got %q", data)
+	}
+
+	// The backup was never read, so its probe permit was never spent.
+	if !cb.Allow("backup") {
+		t.Fatal("backup's probe permit was consumed by a Get that never read it; " +
+			"the site is now unroutable until the process restarts (#94)")
+	}
+	cb.RecordSuccess("backup")
+
+	// And the permit is real: a Get that has to fall through reaches the site.
+	primaryClient := &memClient{getErr: errors.New("primary down"), objects: map[string][]byte{}}
+	c2 := New(site.New("primary", types.SiteRolePrimary, primaryClient), backup)
+	c2.SetCircuitBreaker(cb)
+	got, err := c2.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("fall-through Get: %v", err)
+	}
+	if string(got) != "from-backup" {
+		t.Errorf("fall-through Get: got %q, want from-backup", got)
+	}
+}
+
+// TestCoordinator_Get_RepeatedReadsDoNotExhaustUnusedSites is the cumulative form
+// of the same bug: the permit leak was permanent, so under the old behaviour the
+// unused site was unroutable after the *first* Get and stayed that way.
+func TestCoordinator_Get_RepeatedReadsDoNotExhaustUnusedSites(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("from-primary"),
+	})
+	backup, _ := makeMount("backup", types.SiteRoleBackup, map[string][]byte{
+		"k": []byte("from-backup"),
+	})
+
+	cb := halfOpenBreaker("backup")
+	c := New(primary, backup)
+	c.SetCircuitBreaker(cb)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		if _, err := c.Get(ctx, "k"); err != nil {
+			t.Fatalf("Get %d: %v", i, err)
+		}
+	}
+
+	// Allow is the assertion, not State.  State cannot see this bug: it persists
+	// the Open → HalfOpen transition itself once the cooldown has elapsed, so it
+	// reports HalfOpen for a healthy probe-eligible site and for one holding a
+	// stranded permit alike.  Only Allow distinguishes them, which is exactly why
+	// the leak did not look like a tripped breaker to an operator reading
+	// /api/v1/sites (#94).
+	if !cb.Allow("backup") {
+		t.Error("backup refuses a probe after 10 reads that never touched it; the " +
+			"permit taken by the first Get was never released and never will be (#94)")
+	}
+}
+
+// TestCoordinator_Head_UnusedSiteKeepsItsProbePermit covers the same shape in
+// Head, which is first-hit-wins for the same reason and leaked the same way.
+func TestCoordinator_Head_UnusedSiteKeepsItsProbePermit(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("data"),
+	})
+	backup, _ := makeMount("backup", types.SiteRoleBackup, map[string][]byte{
+		"k": []byte("data"),
+	})
+
+	cb := halfOpenBreaker("backup")
+	c := New(primary, backup)
+	c.SetCircuitBreaker(cb)
+
+	if _, err := c.Head(context.Background(), "k"); err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if !cb.Allow("backup") {
+		t.Error("backup's probe permit was consumed by a Head that never read it (#94)")
+	}
+}
+
+// TestCoordinator_List_DoesNotConsumeProbePermits covers the worst case of the
+// three, which the filed issue did not mention: List called Allow for every
+// candidate and then handed the whole set to the Namespace merge, recording an
+// outcome for none of them.  Every probe-eligible site in a routed set leaked.
+//
+// List is now a pure consumer of breaker state — it filters Open circuits and
+// takes no permits.  See the List doc comment for why recording outcomes there is
+// not a viable alternative.
+func TestCoordinator_List_DoesNotConsumeProbePermits(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"data/a": []byte("a"),
+	})
+	backup, _ := makeMount("backup", types.SiteRoleBackup, map[string][]byte{
+		"data/b": []byte("b"),
+	})
+
+	cb := circuitbreaker.New(1, 0)
+	cb.RecordFailure("primary")
+	cb.RecordFailure("backup")
+
+	c := New(primary, backup)
+	c.SetCircuitBreaker(cb)
+
+	items, err := c.List(context.Background(), "data/", 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("List: got %d items, want 2 (%v)", len(items), items)
+	}
+
+	for _, name := range []string{"primary", "backup"} {
+		if !cb.Allow(name) {
+			t.Errorf("%s's probe permit was consumed by List, which records no "+
+				"outcome for any site and so could never release it (#94)", name)
+		}
+		cb.RecordSuccess(name)
+	}
+}
+
+// TestCoordinator_Get_ProbeOutcomeIsRecordedForTheSiteRead verifies the other half
+// of the pairing: a permit that *is* taken must be released.  A read whose probe
+// succeeds closes the circuit.
+func TestCoordinator_Get_ProbeOutcomeIsRecordedForTheSiteRead(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("v"),
+	})
+	cb := halfOpenBreaker("primary")
+
+	c := New(primary)
+	c.SetCircuitBreaker(cb)
+
+	if _, err := c.Get(context.Background(), "k"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := cb.State("primary"); got != circuitbreaker.StateClosed {
+		t.Errorf("circuit after a successful probe read: got %v, want closed", got)
+	}
+}
+
+// TestCoordinator_Get_MissingKeyDoesNotFailTheProbe is the #77 interaction the
+// issue flagged: the outcome recorded for a probe must not count a not-found as a
+// failure, or the fix trades a permit leak for a breaker that re-opens on every
+// lookup of an absent key.
+func TestCoordinator_Get_MissingKeyDoesNotFailTheProbe(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil) // empty site
+	cb := halfOpenBreaker("primary")
+
+	c := New(primary)
+	c.SetCircuitBreaker(cb)
+
+	_, err := c.Get(context.Background(), "absent")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get of an absent key: got %v, want ErrNotFound", err)
+	}
+	if got := cb.State("primary"); got != circuitbreaker.StateClosed {
+		t.Errorf("circuit after a probe that answered \"no such key\": got %v, "+
+			"want closed — the site answered, which is what the breaker measures "+
+			"(#77, #94)", got)
+	}
+}
+
+// TestCoordinator_Get_AllCircuitsBusyStillReadsASite covers the case the lazy
+// acquisition introduced that the up-front filter could not have: every candidate
+// passes the Open check when the list is built, then refuses the attempt because a
+// concurrent goroutine holds its probe.  The read must still reach a site — a read
+// that attempted nothing cannot tell "absent" from "unreachable", and reporting
+// ErrNotFound for an object that exists is the one answer it must never give.
+func TestCoordinator_Get_AllCircuitsBusyStillReadsASite(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("v"),
+	})
+	cb := circuitbreaker.New(1, 0)
+	cb.RecordFailure("primary")
+	// Take the probe as a concurrent reader would, and never record an outcome.
+	// State is now HalfOpen (so the site survives the Open filter) but Allow
+	// refuses (so the attempt has no permit).
+	if !cb.Allow("primary") {
+		t.Fatal("precondition: expected the probe to be available")
+	}
+	if got := cb.State("primary"); got != circuitbreaker.StateHalfOpen {
+		t.Fatalf("precondition: expected HalfOpen, got %v", got)
+	}
+
+	c := New(primary)
+	c.SetCircuitBreaker(cb)
+
+	data, err := c.Get(context.Background(), "k")
+	if err != nil {
+		t.Fatalf("Get with every candidate's probe outstanding: %v", err)
+	}
+	if string(data) != "v" {
+		t.Errorf("got %q, want v", data)
+	}
+}
+
+// TestCoordinator_Get_ConcurrentReadsDoNotStrandPermits is the unsynchronised
+// check: many concurrent reads against a probe-eligible multi-site set, where the
+// first site always answers.  Whatever the interleaving, no site may be left
+// holding a permit once the reads are done.
+func TestCoordinator_Get_ConcurrentReadsDoNotStrandPermits(t *testing.T) {
+	t.Parallel()
+
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("v"),
+	})
+	backup, _ := makeMount("backup", types.SiteRoleBackup, map[string][]byte{
+		"k": []byte("v"),
+	})
+	burst, _ := makeMount("burst", types.SiteRoleBurst, map[string][]byte{
+		"k": []byte("v"),
+	})
+
+	cb := circuitbreaker.New(1, 0)
+	for _, name := range []string{"primary", "backup", "burst"} {
+		cb.RecordFailure(name)
+	}
+
+	c := New(primary, backup, burst)
+	c.SetCircuitBreaker(cb)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				if _, err := c.Get(ctx, "k"); err != nil {
+					t.Errorf("Get: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, name := range []string{"primary", "backup", "burst"} {
+		if !cb.Allow(name) {
+			t.Errorf("%s is holding a stranded probe permit after 160 concurrent "+
+				"reads (#94)", name)
+		}
+		cb.RecordSuccess(name)
 	}
 }

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -3540,3 +3540,328 @@ func makeMountOnly(name string) *site.SiteMount {
 	m, _ := makeMount(name, types.SiteRoleBackup, nil)
 	return m
 }
+
+// ─── Cache/write races (#89, #90) ──────────────────────────────────────────────
+//
+// The bug these cover is a read-through fill that is not atomic with the read it
+// caches.  Reproducing it needs a site read parked *between* the two halves of
+// Get — after s.Get has produced bytes, before the cache is populated — with a
+// Put or Delete completing in the window.  memClient can gate Put, Health and
+// Close but not Get, and a getFn hook cannot express "block, then release"
+// without the coordination below, so this is its own client.
+
+// gatedGetClient is an ObjectFSClient whose Get blocks until released, so a test
+// can hold a read-through fill open across a concurrent write or delete.
+//
+// Put and Delete deliberately do *not* block: the point is to let the writer run
+// to completion while the reader is parked.
+type gatedGetClient struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	// gate is closed to release parked Gets.  Reads take a snapshot of the value
+	// they will return *before* waiting, which is what makes the reader hold
+	// pre-write bytes: a Get that re-read the map after the gate opened would
+	// observe the new value and the race would be untestable.
+	gate    chan struct{}
+	entered chan struct{} // buffered; one token per Get that reached the gate
+	// delay, when non-zero, is slept after the snapshot instead of waiting on the
+	// gate.  It gives the unsynchronised test a fill window wide enough to hit:
+	// against in-memory sites the read and the fill are microseconds apart, so
+	// unaided concurrency reproduces the race far too rarely to be a regression
+	// test.
+	delay time.Duration
+}
+
+func newGatedGetClient(objs map[string][]byte) *gatedGetClient {
+	if objs == nil {
+		objs = make(map[string][]byte)
+	}
+	return &gatedGetClient{
+		objects: objs,
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}, 16),
+	}
+}
+
+// newSlowGetClient returns a client whose Get snapshots its value, waits delay,
+// and then returns it — a site read with a realistic window between "the bytes
+// were current" and "the bytes reach the caller", with no test coordination.
+func newSlowGetClient(objs map[string][]byte, delay time.Duration) *gatedGetClient {
+	g := newGatedGetClient(objs)
+	g.delay = delay
+	close(g.gate) // never parks; the delay is the window
+	return g
+}
+
+func (g *gatedGetClient) Get(_ context.Context, key string, _, _ int64) ([]byte, error) {
+	g.mu.Lock()
+	data, ok := g.objects[key]
+	var snapshot []byte
+	if ok {
+		snapshot = make([]byte, len(data))
+		copy(snapshot, data)
+	}
+	g.mu.Unlock()
+
+	// Signal before waiting, so the test knows the read is in flight and the
+	// bytes are already determined.
+	select {
+	case g.entered <- struct{}{}:
+	default:
+	}
+	if g.delay > 0 {
+		time.Sleep(g.delay)
+	}
+	<-g.gate
+
+	if !ok {
+		return nil, notFound(key)
+	}
+	return snapshot, nil
+}
+
+func (g *gatedGetClient) Put(_ context.Context, key string, data []byte) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	g.objects[key] = cp
+	return nil
+}
+
+func (g *gatedGetClient) Delete(_ context.Context, key string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.objects, key)
+	return nil
+}
+
+func (g *gatedGetClient) List(_ context.Context, prefix string, _ int) ([]objectfstypes.ObjectInfo, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var out []objectfstypes.ObjectInfo
+	for k, v := range g.objects {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, objectfstypes.ObjectInfo{Key: k, Size: int64(len(v))})
+		}
+	}
+	return out, nil
+}
+
+func (g *gatedGetClient) Head(_ context.Context, key string) (*objectfstypes.ObjectInfo, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	data, ok := g.objects[key]
+	if !ok {
+		return nil, notFound(key)
+	}
+	return &objectfstypes.ObjectInfo{Key: key, Size: int64(len(data))}, nil
+}
+
+func (g *gatedGetClient) Health(context.Context) error { return nil }
+func (g *gatedGetClient) Close() error                 { return nil }
+
+// hasKey reports whether the site still holds key.
+func (g *gatedGetClient) hasKey(key string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.objects[key]
+	return ok
+}
+
+// waitForGet blocks until a Get has reached the gate, so the test can be sure
+// the read is parked with its bytes already chosen.
+func (g *gatedGetClient) waitForGet(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-g.entered:
+	case <-time.After(timeout):
+		t.Fatalf("no Get reached the gate within %v", timeout)
+	}
+}
+
+// release unparks every waiting Get.  Safe to call more than once.
+func (g *gatedGetClient) release() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	select {
+	case <-g.gate:
+		// already closed
+	default:
+		close(g.gate)
+	}
+}
+
+// TestCoordinator_Get_StaleFillAfterPutIsNotCached is the #89 acceptance test.
+//
+// A Get is parked mid-site-read holding "v1"; a Put commits "v2" at the site and
+// invalidates the cache — finding nothing, because the entry does not exist yet;
+// the reader is then released.  Before the generation fence the reader's fill
+// reinstated "v1" with no expiry (TTL defaults to 0), and every later Get was a
+// cache hit on overwritten bytes for the process lifetime.
+func TestCoordinator_Get_StaleFillAfterPutIsNotCached(t *testing.T) {
+	t.Parallel()
+
+	gc := newGatedGetClient(map[string][]byte{"k": []byte("v1")})
+	primary := site.New("primary", types.SiteRolePrimary, gc)
+
+	c := New(primary)
+	c.SetCache(cache.New(cache.Config{MaxBytes: 1 << 20})) // TTL 0: no expiry
+	ctx := context.Background()
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		// The value this read returns is legitimately the pre-write one — it was
+		// current when the read began.  What must not happen is it being cached.
+		_, _ = c.Get(ctx, "k")
+	}()
+
+	gc.waitForGet(t, 5*time.Second)
+
+	// The writer runs to completion while the reader is parked.
+	if err := c.Put(ctx, "k", []byte("v2")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	gc.release()
+	<-readDone
+
+	// The site now holds v2, and the gate is open, so the only way to see v1 is
+	// from the cache.
+	data, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get after Put: %v", err)
+	}
+	if string(data) != "v2" {
+		t.Errorf("Get after a committed Put returned %q, want v2: the parked read's "+
+			"fill reinstated pre-write bytes the Put had already invalidated (#89)", data)
+	}
+}
+
+// TestCoordinator_Get_StaleFillAfterDeleteIsNotCached is the #90 acceptance test.
+//
+// Same race, sharper post-condition: after a Delete that succeeded at every site,
+// the object must be *unreadable*, not merely current.  The cache is the only
+// copy left, so a fill that lands after the delete means a deletion the system
+// reported as fully successful did not make the data unreadable.
+func TestCoordinator_Get_StaleFillAfterDeleteIsNotCached(t *testing.T) {
+	t.Parallel()
+
+	gc := newGatedGetClient(map[string][]byte{"phi/record": []byte("SENSITIVE")})
+	primary := site.New("primary", types.SiteRolePrimary, gc)
+
+	c := New(primary)
+	c.SetCache(cache.New(cache.Config{MaxBytes: 1 << 20}))
+	ctx := context.Background()
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		_, _ = c.Get(ctx, "phi/record")
+	}()
+
+	gc.waitForGet(t, 5*time.Second)
+
+	if err := c.Delete(ctx, "phi/record"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if gc.hasKey("phi/record") {
+		t.Fatal("precondition: the delete did not remove the object from the site")
+	}
+
+	gc.release()
+	<-readDone
+
+	data, err := c.Get(ctx, "phi/record")
+	if err == nil {
+		t.Fatalf("a fully-deleted object is still readable: Get returned %q (#90)", data)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after Delete: got %v, want an error wrapping ErrNotFound", err)
+	}
+}
+
+// TestCoordinator_Get_UncontendedFillStillPopulatesCache guards the other
+// direction of the fence.  If it over-refused, the cache would never populate and
+// the fix would be a silent performance regression that no correctness test
+// notices.
+func TestCoordinator_Get_UncontendedFillStillPopulatesCache(t *testing.T) {
+	t.Parallel()
+
+	primary, mc := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("v"),
+	})
+	c := New(primary)
+	c.SetCache(cache.New(cache.Config{MaxBytes: 1 << 20}))
+	ctx := context.Background()
+
+	if _, err := c.Get(ctx, "k"); err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+
+	// Remove the object from the site.  A second Get can now only succeed from
+	// the cache, so serving it proves the first Get's fill was accepted.
+	if err := mc.Delete(ctx, "k"); err != nil {
+		t.Fatalf("site Delete: %v", err)
+	}
+	data, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("second Get: the read-through fill was refused even with no "+
+			"concurrent invalidation: %v", err)
+	}
+	if string(data) != "v" {
+		t.Errorf("cached read: got %q, want v", data)
+	}
+}
+
+// TestCoordinator_Get_ConcurrentWritesNeverLeaveStaleCache is the unsynchronised
+// version: readers and writers on one key with no gate holding an interleaving
+// open, under -race.  It exists because the gated tests pin one ordering and the
+// fix has to hold for all of them.
+//
+// The site read carries a millisecond of latency, which is what makes this a
+// regression test rather than a coin flip: against a purely in-memory site the
+// read and the fill are microseconds apart and the window is almost never hit.
+// The invariant asserted is the one that matters — once the writes have settled, a
+// read must not return an earlier value.
+func TestCoordinator_Get_ConcurrentWritesNeverLeaveStaleCache(t *testing.T) {
+	t.Parallel()
+
+	gc := newSlowGetClient(map[string][]byte{"k": []byte("v0")}, time.Millisecond)
+	primary := site.New("primary", types.SiteRolePrimary, gc)
+
+	c := New(primary)
+	c.SetCache(cache.New(cache.Config{MaxBytes: 1 << 20}))
+	ctx := context.Background()
+
+	const writes = 30
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= writes; i++ {
+			if err := c.Put(ctx, "k", []byte(fmt.Sprintf("v%d", i))); err != nil {
+				t.Errorf("Put %d: %v", i, err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < writes*4; i++ {
+			_, _ = c.Get(ctx, "k")
+		}
+	}()
+	wg.Wait()
+
+	final := fmt.Sprintf("v%d", writes)
+	data, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("final Get: %v", err)
+	}
+	if string(data) != final {
+		t.Errorf("final Get returned %q, want %q: a read-through fill outlived a "+
+			"later write, and with TTL defaulting to 0 nothing ages it out (#89)", data, final)
+	}
+}


### PR DESCRIPTION
Three read-path bugs in the v0.2.3 milestone. Two share a mechanism (#89, #90); the third (#94) is independent but lives in the same loops.

Scope note: this branch touches only the read paths in `internal/coordinator` (`Get`, `List`, `Head`, `filterByCircuitBreaker`) plus all of `internal/cache`. `Put` and `Delete` are unmodified — the generation bump happens inside `cache.Delete`, so their existing `oc.Delete(key)` calls invalidate correctly with no edit at either call site.

## #89 / #90 — read-through fills undid invalidations

A fill is two steps with a network round-trip between them. A reader took a miss, fetched from a site, and inserted the bytes some time later; an invalidation landing in that window was lost, because `Delete` removed an entry that did not exist yet and the in-flight fill then wrote pre-write bytes on top of the hole. Nothing bounded it: `Cache.TTL` defaults to 0 and `expiresAt` is only set when TTL > 0, so the entry left only under LRU byte pressure.

Every invalidation now bumps a counter. `Get` reads it on the cache miss — before the site read, the only placement that works — and fills with `PutIfUnchanged`, which compares and inserts under one lock acquisition. `Delete` bumps whether or not the key was present; that is the load-bearing part, since the case that matters is precisely the one where it is absent because a fill is still in flight.

The counter is global, as the issue suggests. A spurious skip is a cache miss, which is always safe, so per-key tracking would buy a hit-rate optimisation in exchange for state to garbage collect.

#90 gets its own test with its own post-condition: after a delete that succeeded at every site, the object is **unreadable**, not merely current.

## #94 — HalfOpen probe permits leaked, locking sites out permanently

`Allow` is not a predicate — on a HalfOpen circuit it takes the single probe permit, released only by a recorded outcome. `filterByCircuitBreaker` called it for every candidate; `Get`/`Head` stop at the first site that answers. Unused candidates kept a permit nothing would release, so the site left read routing for the process lifetime while `State` reported HalfOpen rather than Open — invisible in `/api/v1/sites`.

`filterByCircuitBreaker` now tests `State`, which answers the same routing question and consumes nothing. `Get` and `Head` range over a new `attemptableSites` iterator that takes each permit as it yields the site, paired one-to-one with the `recordSiteResult` that releases it. Outcomes still go through `recordSiteResult`, so #77's classification holds and a probe answering "no such key" records a success.

The all-open fallback is preserved and needed a second form: splitting acquisition from filtering makes them two decisions, so a site that was non-Open when the candidate list was built can refuse the attempt a moment later. `attemptableSites` re-yields the candidates with no permit required if the breaker refused every one — without it a read could attempt nothing and return `ErrNotFound` on the strength of never having looked.

**`List` — not in the filed issue, and the worst of the three.** It called `Allow` for every candidate and handed the whole set to the `Namespace` merge, recording an outcome for none, so every probe-eligible site in a routed set leaked. It is now a pure consumer of breaker state: filters Open circuits, takes no permits, records nothing. Recording outcomes there is not viable — `namespace.List` folds per-site failures into one joined error, so `List` cannot attribute an outcome without reimplementing the merge — and excluding a HalfOpen site would silently truncate the namespace, the one failure mode `List` must not have. Including it can only add keys to a listing that already tolerates unreachable sites. The reasoning is in the doc comment so the apparent inconsistency with `Get`/`Head` is not "fixed" later.

## Test evidence

Every fix has a test verified to fail before and pass after, by reverting each fix individually against the new tests:

- Reverting only the `cache.Delete` generation bump fails 4 cache tests, including `PutIfUnchanged_DropsAfterDelete` ("deleted key is readable from the cache").
- Reverting only `Get`'s fill to `PutAndRecordEvictions` fails both acceptance tests: `Get after a committed Put returned "v1", want v2` and `a fully-deleted object is still readable: Get returned "SENSITIVE"`.
- Reverting only `filterByCircuitBreaker`/the loops fails 5 breaker tests across `Get`, `Head`, `List`, and the concurrent case.

The two gated tests park a real read: `gatedGetClient.Get` snapshots the value it will return and then blocks, so the reader genuinely holds pre-write bytes. `memClient` can gate Put/Health/Close but not Get, hence the separate client.

The unsynchronised cache test gives the site read a millisecond of latency on purpose — against an in-memory site the read and fill are microseconds apart and it passes on the broken code. With the delay it fails pre-fix at every `-cpu` value.

`go build ./...`, `go test -race ./...`, and `gofmt -l .` are clean. Cache, coordinator and circuitbreaker packages pass `-race -count=5 -cpu=1,2,4`. `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` reports the same 119 pre-existing issues as `main`, none in the changed files.

## Deliberately out of scope

**`Cache.TTL` still defaults to 0.** The issue floats a non-zero default as defence in depth and calls it a separate judgement call; `pkg/config/config.go` is outside this branch. Recommendation for the maintainer: set it, in the 5–15 minute range. It fixes nothing here — the fence is the fix — but it converts any future staleness bug from unbounded to bounded, and an unbounded stale entry is the part of #89/#90 that made them severity-high rather than a transient inconsistency. The cost is a periodic re-fetch of hot objects.

`CHANGELOG.md` untouched, per the maintainer's reservation.
