### PR TITLE
fix: make Delete mean deleted (#87, #88, #91, #92)

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -11,8 +11,9 @@
 //   - Get/Head: tries sites in the routed order, returns the first success.
 //   - Put: writes synchronously to primary-role sites in the routed set;
 //     asynchronously replicates to non-primary sites via the replication.Worker.
-//   - Delete: synchronous on primary-role sites (errors returned);
-//     best-effort on non-primaries (errors logged).
+//   - Delete: synchronous on every routed site, primaries first; returns nil
+//     only if the object is gone everywhere, otherwise an error naming the sites
+//     that still hold it (#87).
 //   - List: delegates to the embedded Namespace (priority-merge, no policy).
 //
 // # Lifecycle
@@ -1344,15 +1345,10 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 		return fmt.Errorf("coordinator: Put %q: policy error: %w", key, err)
 	}
 
-	primaries, others := partitionByRole(routed)
-
-	// If the routed set has no primaries (e.g. a burst-only policy rule),
-	// promote the first site to a synchronous write target so the data is
-	// persisted before Put returns.
-	if len(primaries) == 0 && len(others) > 0 {
-		primaries = others[:1]
-		others = others[1:]
-	}
+	// partitionForWrite promotes the first non-primary when the routed set has no
+	// primaries (e.g. a burst-only policy rule), so the data is persisted before
+	// Put returns.  Delete uses the same helper (#88).
+	primaries, others := partitionForWrite(routed)
 
 	// Invalidate the cache on every path out of Put, not only the success path.
 	//
@@ -1502,11 +1498,52 @@ func enqueueWithBackpressure(ctx context.Context, worker *replication.Worker, bu
 	}
 }
 
-// Delete removes the object at key from sites in the policy-routed set.
+// ErrDeleteIncomplete reports that a Delete removed the object from some of the
+// routed sites but not all of them, so the object is still readable.
 //
-// Primary site deletes are synchronous and return errors on failure.
-// Non-primary deletes are best-effort: errors are logged but not returned.
-// The cache entry for key is invalidated regardless of per-site outcome.
+// It is the delete-side counterpart of [ErrReplicationNotQueued]: a partial
+// outcome that neither "succeeded" nor "failed" describes honestly.  The error
+// message names every site that may still hold the object, and the underlying
+// cause of the first such failure is wrapped, so errors.Is finds both this
+// sentinel and the reason.
+//
+// Retrying the identical Delete is safe and is the intended response.  Delete is
+// idempotent at every site: a site that no longer has the key answers "no such
+// key", which Delete counts as already-deleted rather than as a failure, so a
+// retry converges on nil once the unwell sites recover.
+//
+// Nothing in GlobalFS retries on the caller's behalf.  There is no tombstone and
+// no queued delete job — the durable job machinery would need the metadata store,
+// which no shipped deployment wires — so an error wrapping this sentinel is the
+// only signal that exists, and a caller that discards it has an object it
+// believes is erased and that [Coordinator.Get] will still serve from the
+// surviving replica (#87).
+var ErrDeleteIncomplete = errors.New("delete incomplete; object still present at some sites")
+
+// Delete removes the object at key from every site in the policy-routed set.
+//
+// Delete is all-or-report: it returns nil only when every routed site confirmed
+// the object is gone.  If any site failed to delete it, Delete returns an error
+// wrapping [ErrDeleteIncomplete] that names the sites which may still hold the
+// object, and increments globalfs_delete_incomplete_total.  A site that answers
+// "no such key" counts as gone, not as a failure, so repeating a Delete is safe.
+//
+// Every routed site is attempted even after one fails, primaries first.  The
+// previous behaviour returned on the first primary error, which left the replicas
+// untouched, and logged-and-discarded every non-primary error, which meant a
+// delete that removed nothing from a burst site still reported success while Get
+// went on serving the surviving copy (#87, #88).  Removing the object from as
+// many sites as possible and then naming the rest is strictly better for a caller
+// under an erasure obligation than stopping at the first refusal.
+//
+// The cache entry for key is invalidated on every path, including the incomplete
+// one: the object was removed somewhere, so the cached copy is wrong either way.
+//
+// An HTTP layer in front of this may want to distinguish the partial case (the
+// object exists at a named subset of sites, and retrying is the fix) from a
+// delete that achieved nothing.  cmd/coordinator currently maps every Delete
+// error to 502, which is defensible for both but tells the client less than it
+// could; refining it is tracked separately.
 func (c *Coordinator) Delete(ctx context.Context, key string) error {
 	c.mu.RLock()
 	snapshot, pol, cb, oc := c.snapshotSites(), c.policy, c.cb, c.objCache
@@ -1517,29 +1554,82 @@ func (c *Coordinator) Delete(ctx context.Context, key string) error {
 		return fmt.Errorf("coordinator: Delete %q: policy error: %w", key, err)
 	}
 
-	primaries, others := partitionByRole(routed)
+	// The promotion in partitionForWrite is what makes a burst-only delete rule
+	// report anything at all: without it every site is a non-primary and, before
+	// this, every non-primary error was discarded (#88).  It matters less now that
+	// both loops report, but Put and Delete sharing one partition keeps the two
+	// from drifting apart again.
+	primaries, others := partitionForWrite(routed)
 
-	for _, s := range primaries {
-		if err := s.Delete(ctx, key); err != nil {
-			recordSiteResult(cb, s.Name(), err)
-			return fmt.Errorf("coordinator: Delete %q from primary %q: %w", key, s.Name(), err)
-		}
-		recordSiteResult(cb, s.Name(), nil)
-	}
-	for _, s := range others {
-		err := s.Delete(ctx, key)
-		recordSiteResult(cb, s.Name(), err)
-		if err != nil {
-			slog.Warn("coordinator: Delete from non-primary site", "key", key, "site", s.Name(), "error", err)
-		}
-	}
-
-	// Invalidate the cache entry whether or not site deletes succeeded.
+	// Invalidate on every path out of Delete, for the same reason Put does (#91).
 	if oc != nil {
-		oc.Delete(key)
-		c.metricsCacheBytes(oc.Stats().Bytes)
+		defer func() {
+			oc.Delete(key)
+			c.metricsCacheBytes(oc.Stats().Bytes)
+		}()
+	}
+
+	// Primaries first, then the rest, in one loop so both get identical
+	// treatment.  Built into a fresh slice rather than appending others onto
+	// primaries: after the promotion above, primaries aliases others' backing
+	// array, and appending to it would write through into the slice being
+	// appended from.
+	targets := make([]*site.SiteMount, 0, len(primaries)+len(others))
+	targets = append(targets, primaries...)
+	targets = append(targets, others...)
+
+	// remaining collects the sites that may still hold the object, so the error
+	// names all of them rather than only the first.  cause keeps the first
+	// underlying error for errors.Is.
+	var remaining []string
+	var cause error
+	for _, s := range targets {
+		siteErr := s.Delete(ctx, key)
+		recordSiteResult(cb, s.Name(), siteErr)
+		if !objectStillPresentAfterDelete(siteErr) {
+			continue
+		}
+		remaining = append(remaining, s.Name())
+		if cause == nil {
+			cause = siteErr
+		}
+		slog.Error("coordinator: Delete failed; the object is still readable at this site",
+			"key", key, "site", s.Name(), "role", s.Role(), "error", siteErr)
+	}
+
+	if len(remaining) > 0 {
+		// Counter as well as log: a delete that did not happen everywhere is an
+		// integrity event that has to stay visible after the log line scrolls,
+		// and for a deployment under a retention obligation it is the only
+		// machine-readable record that the API reported an erasure it did not
+		// perform (#87).
+		c.metrics().RecordDeleteIncomplete()
+		return fmt.Errorf("coordinator: Delete %q: %w: %v: %w",
+			key, ErrDeleteIncomplete, remaining, cause)
 	}
 	return nil
+}
+
+// objectStillPresentAfterDelete reports whether a site's Delete error leaves the
+// object readable at that site.
+//
+// A "no such key" answer does not: the site was reached, it answered, and its
+// answer is that the object is absent — which is the state Delete wanted.  Any
+// other error is treated as "it may still be there", because the coordinator
+// cannot tell a refused delete from a delete that happened and failed to
+// acknowledge, and assuming the object survived is the direction that reports a
+// problem instead of hiding one.
+//
+// This is the same classification isSiteFailure makes for the circuit breaker
+// (#77) and it has to be made twice, for different questions: the breaker asks
+// whether the site is unwell, Delete asks whether the object is gone.  A backend
+// that reports not-found on a repeat delete would otherwise make every retry of
+// an already-completed Delete look incomplete forever.
+func objectStillPresentAfterDelete(err error) bool {
+	if err == nil {
+		return false
+	}
+	return !errors.Is(err, objectfssdk.ErrNotFound)
 }
 
 // List returns up to limit objects under prefix, merged across policy-routed sites.
@@ -1891,6 +1981,32 @@ func attemptableSites(cb *circuitbreaker.Breaker, sites []*site.SiteMount, bypas
 			}
 		}
 	}
+}
+
+// partitionForWrite splits routed into the sites a mutation must be applied to
+// synchronously — and whose errors therefore reach the caller — and the sites it
+// is applied to asynchronously (Put) or after the synchronous ones (Delete).
+//
+// It is partitionByRole plus one rule: if the routed set contains no primary at
+// all, the first non-primary is promoted into primaries.  A policy rule whose
+// TargetRoles is [burst] produces exactly that set, and without the promotion
+// there is no synchronous target, so the caller cannot learn whether the
+// mutation happened.  For Put that meant data that was never durably stored
+// anywhere before Put returned nil; for Delete it meant nil under *every*
+// outcome, because every site landed in the loop that logged its errors and
+// discarded them (#88).
+//
+// Put and Delete share this instead of each inlining it because they already
+// drifted apart once: Put grew the promotion with a comment explaining why it
+// was necessary, Delete never did, and neither call site shows the omission on
+// its own.
+func partitionForWrite(routed []*site.SiteMount) (primaries, others []*site.SiteMount) {
+	primaries, others = partitionByRole(routed)
+	if len(primaries) == 0 && len(others) > 0 {
+		primaries = others[:1]
+		others = others[1:]
+	}
+	return primaries, others
 }
 
 // partitionByRole splits sites into primary-role and non-primary slices,

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -1354,6 +1354,26 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 		others = others[1:]
 	}
 
+	// Invalidate the cache on every path out of Put, not only the success path.
+	//
+	// Primaries are written sequentially and the first failure returns
+	// immediately, so a Put that reports an error may still have mutated an
+	// earlier primary.  When the invalidation lived at the end of the function
+	// the error path skipped it and readers kept being served the pre-Put value
+	// from cache — with the default TTL of 0, for as long as the process ran
+	// (#91).  A defer taken here, before the first site is touched, covers the
+	// early returns below by construction rather than by remembering to.
+	//
+	// Invalidating more than strictly necessary is the safe direction: a
+	// spurious invalidation costs one cache miss, a missed one serves stale data
+	// indefinitely.
+	if oc != nil {
+		defer func() {
+			oc.Delete(key)
+			c.metricsCacheBytes(oc.Stats().Bytes)
+		}()
+	}
+
 	for _, s := range primaries {
 		if err := s.Put(ctx, key, data); err != nil {
 			recordSiteResult(cb, s.Name(), err)
@@ -1431,14 +1451,6 @@ func (c *Coordinator) Put(ctx context.Context, key string, data []byte) error {
 				}
 			}
 		}
-	}
-
-	// Invalidate the cache so the next Get fetches the freshly-written value.
-	// Done before the partial-success return: the primary write happened, so a
-	// cached copy of the old value is stale either way.
-	if oc != nil {
-		oc.Delete(key)
-		c.metricsCacheBytes(oc.Stats().Bytes)
 	}
 
 	if len(notQueued) > 0 {

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -475,18 +475,40 @@ func TestCoordinator_Delete_RemovesFromAllPrimaries(t *testing.T) {
 	}
 }
 
-// TestCoordinator_Delete_NonPrimaryErrorIgnored verifies that a failure on a
-// non-primary site during Delete does not surface to the caller.
-func TestCoordinator_Delete_NonPrimaryErrorIgnored(t *testing.T) {
+// TestCoordinator_Delete_NonPrimaryErrorIsReported is the inversion of what this
+// test used to assert.  It was named _NonPrimaryErrorIgnored and it verified that
+// a failed replica delete did not surface to the caller — which is exactly the
+// defect in #87: the API returned 204 for an object that was still readable from
+// the surviving replica, with no signal to the operator.
+//
+// The primary delete still happens, so the fix is not "give up on the first
+// failure": as much of the object as can be removed is removed, and the sites
+// that still hold it are named.
+func TestCoordinator_Delete_NonPrimaryErrorIsReported(t *testing.T) {
 	t.Parallel()
 
-	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
 	burstClient := &memClient{delErr: errors.New("unavailable"), objects: map[string][]byte{"k": []byte("v")}}
 	burst := site.New("burst", types.SiteRoleBurst, burstClient)
 
 	c := New(primary, burst)
-	if err := c.Delete(context.Background(), "k"); err != nil {
-		t.Errorf("Delete: non-primary error should be ignored, got: %v", err)
+	err := c.Delete(context.Background(), "k")
+	if err == nil {
+		t.Fatal("Delete returned nil while the burst site still holds the object (#87)")
+	}
+	if !errors.Is(err, ErrDeleteIncomplete) {
+		t.Errorf("Delete error does not wrap ErrDeleteIncomplete, so a caller cannot tell a "+
+			"partial delete from a total failure: %v", err)
+	}
+	if !strings.Contains(err.Error(), "burst") {
+		t.Errorf("Delete error does not name the site that still holds the object: %v", err)
+	}
+	if primaryClient.hasKey("k") {
+		t.Error("primary still holds the object: a failing replica must not stop the deletes " +
+			"that can succeed")
+	}
+	if !burstClient.hasKey("k") {
+		t.Error("test setup is wrong: the burst client should still hold the object")
 	}
 }
 
@@ -4183,6 +4205,287 @@ func TestCoordinator_Get_ConcurrentReadsDoNotStrandPermits(t *testing.T) {
 	}
 }
 
+// ── Delete correctness (#87, #88) ─────────────────────────────────────────────
+
+// TestCoordinator_Delete_IncompleteDeleteLeavesObjectReadable is the #87
+// reproduction in full: the delete fails at one site, and the object remains
+// retrievable through the same API that was asked to remove it.
+//
+// The assertion on Get is deliberately an assertion about the *current* read
+// path, not a wish: Get takes the first site that answers, so a surviving replica
+// is served, and nothing in Delete can change that.  What Delete owes the caller
+// is the truth — an error naming the site that still holds the object — so that
+// the condition is actionable rather than invisible.  Before this fix Delete
+// returned nil here and the only trace was a Warn line.
+func TestCoordinator_Delete_IncompleteDeleteLeavesObjectReadable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"phi/patient.csv": []byte("record"),
+	})
+	burstClient := &memClient{
+		delErr:  errors.New("service unavailable"),
+		objects: map[string][]byte{"phi/patient.csv": []byte("record")},
+	}
+	burst := site.New("burst", types.SiteRoleBurst, burstClient)
+
+	c := New(primary, burst)
+
+	err := c.Delete(ctx, "phi/patient.csv")
+	if err == nil {
+		t.Fatal("Delete reported success for an object that is still present at the burst site; " +
+			"under a retention or erasure obligation that is a compliance-grade lie (#87)")
+	}
+	if !errors.Is(err, ErrDeleteIncomplete) {
+		t.Errorf("Delete error must wrap ErrDeleteIncomplete so callers can distinguish a partial "+
+			"delete from a total one: %v", err)
+	}
+	if !strings.Contains(err.Error(), "burst") {
+		t.Errorf("Delete error must name the sites that still hold the object: %v", err)
+	}
+
+	// The primary delete happened, and the surviving replica is still served —
+	// which is precisely why Delete has to report rather than swallow.
+	if primaryClient.hasKey("phi/patient.csv") {
+		t.Error("primary still holds the object")
+	}
+	data, getErr := c.Get(ctx, "phi/patient.csv")
+	if getErr != nil {
+		t.Fatalf("Get after the incomplete delete: %v (expected the surviving replica to answer)", getErr)
+	}
+	if string(data) != "record" {
+		t.Errorf("Get returned %q, want the surviving replica's %q", data, "record")
+	}
+	t.Log("Get still serves the object from the burst replica; the delete error is the only " +
+		"signal the caller has that this is the case")
+}
+
+// TestCoordinator_Delete_IncompleteIncrementsCounter checks the counter, not the
+// log line.  A log line is gone as soon as it scrolls, and an incomplete delete
+// has to stay attributable afterwards — for a deployment under an erasure
+// obligation this counter is the only machine-readable record that the API
+// reported a deletion it did not perform.
+func TestCoordinator_Delete_IncompleteIncrementsCounter(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	primary, _ := makeMount("primary", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	burstClient := &memClient{delErr: errors.New("unavailable"), objects: map[string][]byte{"k": []byte("v")}}
+	burst := site.New("burst", types.SiteRoleBurst, burstClient)
+
+	c := New(primary, burst)
+	mustConfigure(t, c.SetMetrics(metrics.New(reg)))
+
+	if err := c.Delete(context.Background(), "k"); err == nil {
+		t.Fatal("Delete: expected an error for an incomplete delete")
+	}
+
+	if got := counterValue(t, reg, "globalfs_delete_incomplete_total"); got != 1 {
+		t.Errorf("globalfs_delete_incomplete_total = %v, want 1; an object reported deleted and "+
+			"still readable has to be observable after the log scrolls", got)
+	}
+}
+
+// TestCoordinator_Delete_AllSitesAttemptedAfterPrimaryFailure covers the other
+// half of the old behaviour: Delete returned on the first primary error, so the
+// replicas were never even asked.  That maximised the number of surviving copies
+// of an object the caller wanted gone.
+//
+// Every routed site is now attempted, and every site that may still hold the
+// object is named — not just the first.
+func TestCoordinator_Delete_AllSitesAttemptedAfterPrimaryFailure(t *testing.T) {
+	t.Parallel()
+
+	p1Client := &memClient{delErr: errors.New("primary-1 unavailable"), objects: map[string][]byte{"k": []byte("v")}}
+	p1 := site.New("primary-1", types.SiteRolePrimary, p1Client)
+	p2Client := &memClient{delErr: errors.New("primary-2 unavailable"), objects: map[string][]byte{"k": []byte("v")}}
+	p2 := site.New("primary-2", types.SiteRolePrimary, p2Client)
+	backup, backupClient := makeMount("backup", types.SiteRoleBackup, map[string][]byte{"k": []byte("v")})
+
+	c := New(p1, p2, backup)
+	err := c.Delete(context.Background(), "k")
+	if err == nil {
+		t.Fatal("Delete: expected an error when two primaries refuse")
+	}
+
+	// The healthy site was reached despite both earlier failures.
+	if backupClient.hasKey("k") {
+		t.Error("backup still holds the object: Delete stopped at the first primary failure " +
+			"instead of removing every copy it could (#87)")
+	}
+	for _, name := range []string{"primary-1", "primary-2"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("Delete error does not name %q, so an operator cannot tell which sites to "+
+				"chase: %v", name, err)
+		}
+	}
+	if strings.Contains(err.Error(), "backup") {
+		t.Errorf("Delete error names the site the object was successfully removed from: %v", err)
+	}
+}
+
+// TestCoordinator_Delete_NotFoundIsNotIncomplete pins the idempotence that makes
+// "retry the same Delete" a usable instruction.  A site that no longer has the
+// key answers "no such key", which is the state Delete wanted; counting it as a
+// failure would make every repeat of a completed delete report incomplete
+// forever, and would open the circuit breaker on healthy sites the same way #77
+// did.
+func TestCoordinator_Delete_NotFoundIsNotIncomplete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	// Neither site has the key, and both answer with the code-matched not-found a
+	// real objectfs client returns.
+	primaryClient := &memClient{delErr: notFound("gone"), objects: map[string][]byte{}}
+	primary := site.New("primary", types.SiteRolePrimary, primaryClient)
+	burstClient := &memClient{delErr: notFound("gone"), objects: map[string][]byte{}}
+	burst := site.New("burst", types.SiteRoleBurst, burstClient)
+
+	c := New(primary, burst)
+	if err := c.Delete(ctx, "gone"); err != nil {
+		t.Errorf("Delete of an already-absent object reported incomplete: %v — a retry of a "+
+			"completed delete must converge on nil", err)
+	}
+}
+
+// TestCoordinator_Delete_BurstOnlyRouteReportsFailure is #88, and it contrasts
+// Put and Delete on the identical route because that is where the defect lived:
+// two adjacent functions that partition routed sites the same way, only one of
+// which handled the no-primaries case.
+//
+// With TargetRoles [burst] every site is a non-primary, so before the shared
+// partition Delete had no synchronous target at all and returned nil under every
+// outcome — including this one, where nothing was deleted anywhere.
+func TestCoordinator_Delete_BurstOnlyRouteReportsFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, map[string][]byte{
+		"scratch.tmp": []byte("v"),
+	})
+	burstClient := &memClient{
+		delErr:  errors.New("burst unavailable"),
+		putErr:  errors.New("burst unavailable"),
+		objects: map[string][]byte{"scratch.tmp": []byte("v")},
+	}
+	burst := site.New("burst", types.SiteRoleBurst, burstClient)
+
+	c := New(primary, burst)
+	// One route, both operations: *.tmp → burst only.
+	c.SetPolicy(policy.New(policy.Rule{
+		Name:        "tmp-to-burst",
+		KeyPattern:  "*.tmp",
+		Operations:  []policy.OperationType{policy.OperationWrite, policy.OperationDelete},
+		TargetRoles: []types.SiteRole{types.SiteRoleBurst},
+		Priority:    1,
+	}))
+
+	// Put on this route already surfaced its error, thanks to the promotion.
+	if err := c.Put(ctx, "scratch.tmp", []byte("new")); err == nil {
+		t.Fatal("Put on a burst-only route returned nil while the only target refused the write; " +
+			"the promotion this test contrasts against is missing")
+	}
+
+	err := c.Delete(ctx, "scratch.tmp")
+	if err == nil {
+		t.Fatal("Delete on a burst-only route returned nil although nothing was deleted anywhere: " +
+			"with no primaries in the routed set Delete could not report any failure at all (#88)")
+	}
+	if !errors.Is(err, ErrDeleteIncomplete) {
+		t.Errorf("Delete error must wrap ErrDeleteIncomplete: %v", err)
+	}
+	// The policy excluded the primary from the delete route, so it is untouched —
+	// and correctly not named in the error, which lists only sites that were asked.
+	if !primaryClient.hasKey("scratch.tmp") {
+		t.Error("the primary was deleted from despite being excluded by the delete route")
+	}
+}
+
+// TestPartitionForWrite_PromotesWhenNoPrimaries tests the shared helper directly,
+// because the point of extracting it was that neither call site shows the
+// omission on its own: Put grew the promotion with a comment explaining why it
+// was necessary and Delete simply never did (#88).
+func TestPartitionForWrite_PromotesWhenNoPrimaries(t *testing.T) {
+	t.Parallel()
+
+	burst1, _ := makeMount("burst-1", types.SiteRoleBurst, nil)
+	burst2, _ := makeMount("burst-2", types.SiteRoleBurst, nil)
+
+	primaries, others := partitionForWrite([]*site.SiteMount{burst1, burst2})
+	if len(primaries) != 1 || primaries[0].Name() != "burst-1" {
+		t.Fatalf("promotion did not produce exactly one synchronous target: primaries=%v",
+			siteNames(primaries))
+	}
+	if len(others) != 1 || others[0].Name() != "burst-2" {
+		t.Errorf("others = %v, want [burst-2]", siteNames(others))
+	}
+
+	// A set that already has a primary is partitioned by role, unchanged.
+	primary, _ := makeMount("primary", types.SiteRolePrimary, nil)
+	primaries, others = partitionForWrite([]*site.SiteMount{burst1, primary, burst2})
+	if len(primaries) != 1 || primaries[0].Name() != "primary" {
+		t.Errorf("primaries = %v, want [primary]", siteNames(primaries))
+	}
+	if len(others) != 2 {
+		t.Errorf("others = %v, want both burst sites", siteNames(others))
+	}
+
+	// An empty routed set must not panic on others[:1].
+	primaries, others = partitionForWrite(nil)
+	if len(primaries) != 0 || len(others) != 0 {
+		t.Errorf("empty routed set produced primaries=%v others=%v", siteNames(primaries), siteNames(others))
+	}
+}
+
+// TestCoordinator_Delete_PromotedSiteDeletedExactlyOnce guards the aliasing trap
+// in Delete's single loop: after the promotion, primaries is others[:1], so
+// building the target list by appending others onto primaries would write through
+// into the slice being read from.  A promoted site must be visited once, and the
+// remaining sites must still be visited.
+func TestCoordinator_Delete_PromotedSiteDeletedExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	b1 := &countingDeleteClient{memClient: newMemClient(map[string][]byte{"k": []byte("v")})}
+	b2 := &countingDeleteClient{memClient: newMemClient(map[string][]byte{"k": []byte("v")})}
+	burst1 := site.New("burst-1", types.SiteRoleBurst, b1)
+	burst2 := site.New("burst-2", types.SiteRoleBurst, b2)
+
+	c := New(burst1, burst2)
+	if err := c.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if got := b1.deleteCount(); got != 1 {
+		t.Errorf("burst-1 (the promoted site) saw %d deletes, want 1", got)
+	}
+	if got := b2.deleteCount(); got != 1 {
+		t.Errorf("burst-2 saw %d deletes, want 1 — the remaining sites must still be visited", got)
+	}
+}
+
+// countingDeleteClient counts Delete calls so a test can prove each routed site
+// is visited exactly once.
+type countingDeleteClient struct {
+	*memClient
+	countMu sync.Mutex
+	deletes int
+}
+
+func (c *countingDeleteClient) Delete(ctx context.Context, key string) error {
+	c.countMu.Lock()
+	c.deletes++
+	c.countMu.Unlock()
+	return c.memClient.Delete(ctx, key)
+}
+
+func (c *countingDeleteClient) deleteCount() int {
+	c.countMu.Lock()
+	defer c.countMu.Unlock()
+	return c.deletes
+}
+
 // ── Put cache invalidation on the error path (#91) ────────────────────────────
 
 // TestCoordinator_Put_ErrorPathStillInvalidatesCache covers the three-way
@@ -4236,5 +4539,41 @@ func TestCoordinator_Put_ErrorPathStillInvalidatesCache(t *testing.T) {
 	}
 	if string(got) != "B" {
 		t.Errorf("Get returned %q, want primary-1's %q", got, "B")
+	}
+}
+
+// TestCoordinator_Delete_ErrorPathStillInvalidatesCache is the same argument for
+// Delete.  An incomplete delete now returns an error, and that error path must
+// not skip the invalidation: the object was removed from at least one site, so
+// the cached copy is wrong regardless of what the caller is told.
+func TestCoordinator_Delete_ErrorPathStillInvalidatesCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	primary, primaryClient := makeMount("primary", types.SiteRolePrimary, map[string][]byte{"k": []byte("v")})
+	burstClient := &memClient{delErr: errors.New("unavailable"), objects: map[string][]byte{}}
+	burst := site.New("burst", types.SiteRoleBurst, burstClient)
+
+	c := New(primary, burst)
+	oc := cache.New(cache.Config{MaxBytes: 1024})
+	c.SetCache(oc)
+
+	if _, err := c.Get(ctx, "k"); err != nil {
+		t.Fatalf("priming Get: %v", err)
+	}
+	if oc.Len() != 1 {
+		t.Fatalf("test setup is wrong: cache holds %d entries, want 1", oc.Len())
+	}
+
+	if err := c.Delete(ctx, "k"); err == nil {
+		t.Fatal("Delete: expected an error while the burst site refuses")
+	}
+
+	if _, hit := oc.Get("k"); hit {
+		t.Error("the cache still holds the object after an incomplete delete; the primary copy " +
+			"is gone, so what is cached is not any site's current state (#91)")
+	}
+	if primaryClient.hasKey("k") {
+		t.Error("primary still holds the object")
 	}
 }

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -4182,3 +4182,59 @@ func TestCoordinator_Get_ConcurrentReadsDoNotStrandPermits(t *testing.T) {
 		cb.RecordSuccess(name)
 	}
 }
+
+// ── Put cache invalidation on the error path (#91) ────────────────────────────
+
+// TestCoordinator_Put_ErrorPathStillInvalidatesCache covers the three-way
+// disagreement in #91: with two primaries where the second fails, primary-1 holds
+// the new value, primary-2 holds the old one, Put reports failure — and the cache
+// went on serving the pre-Put value, because the invalidation sat after the early
+// return that the error path takes.
+//
+// The caller, the sites and the cache all disagreed, and with TTL defaulting to 0
+// the cache's version of events was permanent.
+func TestCoordinator_Put_ErrorPathStillInvalidatesCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p1Client := newMemClient(map[string][]byte{"k": []byte("A")})
+	p1 := site.New("primary-1", types.SiteRolePrimary, p1Client)
+	p2Client := &memClient{putErr: errors.New("disk full"), objects: map[string][]byte{"k": []byte("A")}}
+	p2 := site.New("primary-2", types.SiteRolePrimary, p2Client)
+
+	c := New(p1, p2)
+	c.SetCache(cache.New(cache.Config{MaxBytes: 1024}))
+
+	// Populate the cache with the pre-Put value.
+	data, err := c.Get(ctx, "k")
+	if err != nil || string(data) != "A" {
+		t.Fatalf("priming Get: data=%q err=%v", data, err)
+	}
+
+	if err := c.Put(ctx, "k", []byte("B")); err == nil {
+		t.Fatal("Put: expected an error when the second primary refuses the write")
+	}
+
+	// primary-1 accepted the write, so "A" is no longer anything's current value.
+	// Read it through the mount rather than the map: the client's own lock is what
+	// makes that safe.
+	onPrimary1, err := p1.Get(ctx, "k", 0, 0)
+	if err != nil {
+		t.Fatalf("reading primary-1 directly: %v", err)
+	}
+	if string(onPrimary1) != "B" {
+		t.Fatalf("test setup is wrong: primary-1 should hold the new value, has %q", onPrimary1)
+	}
+
+	got, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get after the failed Put: %v", err)
+	}
+	if string(got) == "A" {
+		t.Error("Get served the pre-Put value from a cache that was never invalidated, even " +
+			"though primary-1 had already been mutated; with TTL 0 that is indefinite (#91)")
+	}
+	if string(got) != "B" {
+		t.Errorf("Get returned %q, want primary-1's %q", got, "B")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -18,6 +18,7 @@ type Metrics struct {
 	replicationTotal      *prometheus.CounterVec
 	replicationQueueDepth prometheus.Gauge
 	replicationDropped    prometheus.Counter
+	deleteIncomplete      prometheus.Counter
 	cacheHits             prometheus.Counter
 	cacheMisses           prometheus.Counter
 	cacheEvictions        prometheus.Counter
@@ -64,6 +65,11 @@ func New(reg prometheus.Registerer) *Metrics {
 			Help: "Total number of replication jobs rejected because the queue was full. " +
 				"Non-zero means writes were not replicated; alert on any increase.",
 		}),
+		deleteIncomplete: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "globalfs_delete_incomplete_total",
+			Help: "Total number of deletes that left the object present on at least one site. " +
+				"Non-zero means objects reported deleted are still readable; alert on any increase.",
+		}),
 		cacheHits: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "globalfs_cache_hits_total",
 			Help: "Total number of cache hits.",
@@ -88,6 +94,7 @@ func New(reg prometheus.Registerer) *Metrics {
 		m.replicationTotal,
 		m.replicationQueueDepth,
 		m.replicationDropped,
+		m.deleteIncomplete,
 		m.cacheHits,
 		m.cacheMisses,
 		m.cacheEvictions,
@@ -144,6 +151,22 @@ func (m *Metrics) RecordReplicationDropped() {
 		return
 	}
 	m.replicationDropped.Inc()
+}
+
+// RecordDeleteIncomplete increments the count of deletes that could not be
+// completed at every routed site.
+//
+// It is monotonic for the same reason RecordReplicationDropped is: an incomplete
+// delete is an object that is still readable through the same API that just
+// reported it gone, and the operator needs to see that it happened even after
+// a later retry succeeds.  Any non-zero value is a correctness event, and for a
+// deployment under a retention or erasure obligation it is a compliance one
+// (#87).
+func (m *Metrics) RecordDeleteIncomplete() {
+	if m == nil {
+		return
+	}
+	m.deleteIncomplete.Inc()
 }
 
 // RecordCacheHit increments the cache hit counter.

--- a/internal/replication/worker.go
+++ b/internal/replication/worker.go
@@ -8,6 +8,11 @@
 // archive pipeline (tar.zst) for higher-throughput, compressed inter-site
 // transfers.
 //
+// A transfer re-checks the source immediately before the destination PUT and
+// abandons itself if the key has gone, so a delete that lands while the bytes are
+// in flight is not undone by the write that follows it (#92).  See transfer and
+// sourceStillHasKey for the residual window this leaves.
+//
 // # Lifecycle
 //
 // A Worker is single-use.  It moves through exactly three states, in one
@@ -77,6 +82,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -84,6 +90,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	objectfssdk "github.com/scttfrdmn/objectfs/sdks/go/objectfs"
 
 	"github.com/scttfrdmn/globalfs/pkg/site"
 )
@@ -624,6 +632,40 @@ func shortChecksum(s string) string {
 	return s[:n] + "..."
 }
 
+// sourceStillHasKey reports whether the source site still holds job.Key, as a
+// last check before the destination PUT.
+//
+// It is deliberately asymmetric.  Only an unambiguous "no such key" answers
+// false: the site was reached and it says the object is absent, which is the one
+// case where writing it to the destination would be a resurrection.  Every other
+// error — timeout, throttle, auth, a backend that reports absence without the
+// objectfs code — answers true and the transfer proceeds, because treating an
+// unreachable source as a delete would silently drop replication for the whole
+// duration of an outage.  The asymmetry follows from the costs: a spurious
+// abandonment loses a replica with no record beyond one log line and no retry,
+// while a spurious PUT re-creates an object the caller was told was erased.  The
+// second is worse, but only the first is *caused* by guessing wrong about a
+// source that is merely unwell.
+//
+// This narrows the resurrection window from the whole GET → PUT span — which can
+// be minutes for a large object, or the queue wait plus two retry backoffs — to
+// the Head → Put gap.  It does not close it.  A delete that lands inside that gap
+// still resurrects the object, and no amount of re-checking fixes that: the fix
+// is for Delete to invalidate the queued jobs for the key, which needs a durable
+// record of the delete that no shipped deployment has (#92).
+func sourceStillHasKey(ctx context.Context, job ReplicationJob) bool {
+	_, err := job.SourceSite.Head(ctx, job.Key)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, objectfssdk.ErrNotFound) {
+		return false
+	}
+	slog.Warn("replication: pre-PUT source check failed; proceeding with the transfer",
+		"key", job.Key, "src", job.SourceSite.Name(), "error", err)
+	return true
+}
+
 // transfer performs the actual byte movement: GET from source, PUT to dest.
 // Returns the SHA-256 hex of the transferred content and any error.
 //
@@ -635,6 +677,25 @@ func shortChecksum(s string) string {
 // v0.1.0 slow path: simple GET → PUT over the SiteMount interface.
 // Future: replace with CargoShip streaming archive pipeline for large-scale,
 // compressed inter-site transfers (tracked in globalfs #3 follow-on).
+//
+// # Concurrent delete
+//
+// Between the GET and the PUT the object can be deleted, and a PUT that lands
+// after the delete completed everywhere re-creates it at the destination — a
+// site the operator was not looking at, with no error anywhere, which
+// Coordinator.Get then serves from because any replica satisfies a read (#92).
+// The source is therefore re-checked immediately before the PUT and the transfer
+// is abandoned if the key is gone.  See sourceStillHasKey for what that check
+// can and cannot establish, and why it is a narrowing rather than a fix: the
+// Head → Put gap remains, and closing it needs the delete path to invalidate
+// queued jobs, which needs somewhere durable to record delete state.
+//
+// An abandoned transfer is not an error.  It returns ("", nil), so the job
+// settles as EventCompleted with no content hash: there is nothing left to
+// transfer, nothing for the retry loop to achieve, and no hash to record for
+// dedup because no bytes were written.  Reporting it as a failure would spend
+// three attempts and two backoffs re-discovering the same absence and would
+// show an ordinary race as a replication fault.
 func transfer(ctx context.Context, job ReplicationJob) (string, error) {
 	// Fast path: compare checksums before transferring.
 	srcInfo, srcErr := job.SourceSite.Head(ctx, job.Key)
@@ -654,6 +715,18 @@ func transfer(ctx context.Context, job ReplicationJob) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get from %q: %w", job.SourceSite.Name(), err)
 	}
+
+	// Re-check the source before writing.  The GET above may have returned
+	// minutes ago — the job could have waited in the queue, and each retry
+	// re-runs this whole function — and a Delete in that window has already
+	// removed the object from every site by the time we get here (#92).
+	if !sourceStillHasKey(ctx, job) {
+		slog.Info("replication: abandoning transfer; the object is gone from the source",
+			"key", job.Key, "src", job.SourceSite.Name(), "dst", job.DestSite.Name(),
+			"bytes", len(data))
+		return "", nil
+	}
+
 	if err := job.DestSite.Put(ctx, job.Key, data); err != nil {
 		return "", fmt.Errorf("put to %q: %w", job.DestSite.Name(), err)
 	}

--- a/internal/replication/worker_test.go
+++ b/internal/replication/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	objectfserrors "github.com/scttfrdmn/objectfs/pkg/errors"
 	objectfstypes "github.com/scttfrdmn/objectfs/pkg/types"
 
 	"github.com/scttfrdmn/globalfs/pkg/site"
@@ -28,6 +29,11 @@ type failClient struct {
 	// that is precisely the shutdown case StopContext has to bound (#83).
 	putGate     chan struct{}
 	putsEntered int
+	// getGate is putGate's counterpart for Get, and exists to park a transfer at
+	// the exact point #92 is about: after the bytes have been read from the
+	// source and before they are written to the destination.
+	getGate     chan struct{}
+	getsEntered int
 }
 
 func newFailClient(objs map[string][]byte) *failClient {
@@ -39,20 +45,29 @@ func newFailClient(objs map[string][]byte) *failClient {
 
 func (f *failClient) Get(_ context.Context, key string, _, _ int64) ([]byte, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	if len(f.getErrs) > 0 {
 		err := f.getErrs[0]
 		f.getErrs = f.getErrs[1:]
 		if err != nil {
+			f.mu.Unlock()
 			return nil, err
 		}
 	}
 	v, ok := f.data[key]
 	if !ok {
+		f.mu.Unlock()
 		return nil, errors.New("not found")
 	}
 	cp := make([]byte, len(v))
 	copy(cp, v)
+	// The bytes are already read; park here, outside the lock, so the object can
+	// be deleted from this very client while the transfer holds them.
+	gate := f.getGate
+	f.getsEntered++
+	f.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
 	return cp, nil
 }
 
@@ -110,12 +125,67 @@ func (f *failClient) waitForPut(t *testing.T, timeout time.Duration) {
 	t.Fatalf("no Put reached the client within %v — the transfer never started", timeout)
 }
 
-func (f *failClient) Delete(_ context.Context, _ string) error { return nil }
+// blockGets parks every subsequent Get on this client *after* it has copied the
+// bytes out, which is where a transfer sits between reading the source and
+// writing the destination.  The returned release is safe to call more than once.
+func (f *failClient) blockGets() (release func()) {
+	gate := make(chan struct{})
+	f.mu.Lock()
+	f.getGate = gate
+	f.mu.Unlock()
+	var once sync.Once
+	return func() { once.Do(func() { close(gate) }) }
+}
+
+// waitForGet blocks until a Get has reached the gate, i.e. until the transfer is
+// genuinely parked holding the object's bytes.
+func (f *failClient) waitForGet(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		entered := f.getsEntered
+		f.mu.Unlock()
+		if entered >= 1 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("no Get reached the client within %v — the transfer never started", timeout)
+}
+
+func (f *failClient) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.data, key)
+	return nil
+}
+
 func (f *failClient) List(_ context.Context, _ string, _ int) ([]objectfstypes.ObjectInfo, error) {
 	return nil, nil
 }
-func (f *failClient) Head(_ context.Context, _ string) (*objectfstypes.ObjectInfo, error) {
-	return nil, nil
+
+// Head answers from the same map Get and Put use, and reports an absent key with
+// the code-matched objectfs error a real client returns.  A stub that claimed
+// every key existed would make transfer's pre-PUT source check (#92) vacuous in
+// every test that goes near it.
+func (f *failClient) Head(_ context.Context, key string) (*objectfstypes.ObjectInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.data[key]
+	if !ok {
+		return nil, notFound(key)
+	}
+	return &objectfstypes.ObjectInfo{Key: key, Size: int64(len(v))}, nil
+}
+
+// notFound builds the error a real objectfs client returns for an absent key.
+// It is code-matched by errors.Is against objectfssdk.ErrNotFound, which is what
+// sourceStillHasKey classifies on.
+func notFound(key string) error {
+	return objectfserrors.NewError(objectfserrors.ErrCodeObjectNotFound, "object does not exist").
+		WithComponent("failclient").
+		WithContext("key", key)
 }
 func (f *failClient) Health(_ context.Context) error { return nil }
 func (f *failClient) Close() error                   { return nil }
@@ -1375,4 +1445,163 @@ func TestWorker_StopCompletesWithNoEventConsumer(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		t.Fatal("Stop did not return with no event consumer: a blocking terminal send wedged shutdown")
 	}
+}
+
+// ─── Concurrent delete (#92) ───────────────────────────────────────────────────
+
+// TestTransfer_AbandonsWhenSourceKeyDeletedMidFlight is the direct #92
+// reproduction, driven through transfer rather than the worker so the race is
+// deterministic: the source Get is parked after it has handed out the bytes, the
+// object is deleted while the transfer holds them, and only then is the transfer
+// released.
+//
+// Before the pre-PUT source check, the released PUT re-created the object at the
+// destination after a delete that had already succeeded everywhere — and because
+// Coordinator.Get accepts any replica, that resurrected copy was then served to
+// clients for a key the API had reported as erased.
+func TestTransfer_AbandonsWhenSourceKeyDeletedMidFlight(t *testing.T) {
+	t.Parallel()
+
+	src, srcClient := makeMount("src", types.SiteRolePrimary, map[string][]byte{
+		"phi/patient.csv": []byte("record"),
+	})
+	dst, dstClient := makeMount("dst", types.SiteRoleBurst, nil)
+
+	release := srcClient.blockGets()
+	defer release()
+
+	job := ReplicationJob{SourceSite: src, DestSite: dst, Key: "phi/patient.csv"}
+
+	type result struct {
+		hash string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		hash, err := transfer(context.Background(), job)
+		done <- result{hash, err}
+	}()
+
+	// Wait until the transfer is genuinely holding the bytes, then delete.
+	srcClient.waitForGet(t, 2*time.Second)
+	if err := src.Delete(context.Background(), "phi/patient.csv"); err != nil {
+		t.Fatalf("Delete from source: %v", err)
+	}
+	release()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("transfer did not return within 5s")
+	}
+
+	if dstClient.hasKey("phi/patient.csv") {
+		t.Error("the destination has the object after a completed delete: the in-flight " +
+			"transfer resurrected it, and Coordinator.Get will serve it (#92)")
+	}
+	// An abandoned transfer is not a failure: there is nothing left to move, so
+	// spending two more attempts and two backoffs on it would only re-discover
+	// the same absence and report an ordinary race as a replication fault.
+	if got.err != nil {
+		t.Errorf("abandoned transfer reported an error: %v", got.err)
+	}
+	// No bytes were written, so there is no content hash to record for dedup.
+	if got.hash != "" {
+		t.Errorf("abandoned transfer returned content hash %q; nothing was written", got.hash)
+	}
+}
+
+// TestWorker_DeletedMidFlightIsNotResurrected is the same race through the whole
+// worker, because the guard has to hold where it actually runs: inside the retry
+// loop, under safeTransfer's recover, with the job settling through the event
+// channel.  The job must settle on the first attempt rather than being retried.
+func TestWorker_DeletedMidFlightIsNotResurrected(t *testing.T) {
+	t.Parallel()
+
+	src, srcClient := makeMount("src", types.SiteRolePrimary, map[string][]byte{
+		"k": []byte("v"),
+	})
+	dst, dstClient := makeMount("dst", types.SiteRoleBackup, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := srcClient.blockGets()
+	defer release()
+
+	w := fastWorker(4)
+	w.Start(ctx)
+	defer w.Stop()
+
+	if err := w.Enqueue(ReplicationJob{SourceSite: src, DestSite: dst, Key: "k"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	srcClient.waitForGet(t, 2*time.Second)
+	if err := src.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete from source: %v", err)
+	}
+	release()
+
+	// Drain until the job settles; EventStarted comes first and carries no
+	// outcome.
+	var settled ReplicationEvent
+	for {
+		ev, ok := drainEvent(t, w, 5*time.Second)
+		if !ok {
+			t.Fatal("the job never settled")
+		}
+		if ev.Type == EventStarted {
+			continue
+		}
+		settled = ev
+		break
+	}
+
+	if settled.Type != EventCompleted {
+		t.Errorf("job settled as %v (%v), want completed: abandoning a transfer whose object "+
+			"is gone is not a replication failure", settled.Type, settled.Err)
+	}
+	if settled.Attempt != 1 {
+		t.Errorf("job settled on attempt %d, want 1: an absent source must not be retried",
+			settled.Attempt)
+	}
+	if settled.ContentHash != "" {
+		t.Errorf("settled with content hash %q; no bytes were written, so recording one would "+
+			"make the dedup index claim the destination holds content it does not",
+			settled.ContentHash)
+	}
+	if dstClient.hasKey("k") {
+		t.Error("destination has the object after the delete completed (#92)")
+	}
+}
+
+// TestSourceStillHasKey_UnreachableSourceProceeds pins the asymmetry in the
+// guard.  Only a code-matched "no such key" abandons the transfer; a source that
+// merely failed to answer must not, or a throttle or a timeout would silently
+// stop replicating for the duration of the incident, one log line per object and
+// no retry.
+func TestSourceStillHasKey_UnreachableSourceProceeds(t *testing.T) {
+	t.Parallel()
+
+	unreachable := &headErrClient{failClient: newFailClient(nil), err: errors.New("connection reset")}
+	src := site.New("src", types.SiteRolePrimary, unreachable)
+	dst, _ := makeMount("dst", types.SiteRoleBackup, nil)
+
+	job := ReplicationJob{SourceSite: src, DestSite: dst, Key: "k"}
+	if !sourceStillHasKey(context.Background(), job) {
+		t.Error("an unreachable source was read as a delete; replication would stop during " +
+			"any transient source outage")
+	}
+}
+
+// headErrClient fails every Head with a fixed non-not-found error.
+type headErrClient struct {
+	*failClient
+	err error
+}
+
+func (h *headErrClient) Head(_ context.Context, _ string) (*objectfstypes.ObjectInfo, error) {
+	return nil, h.err
 }


### PR DESCRIPTION
Four filed issues, all reachable from one sentence: a `DELETE` that returned 204
did not mean the object was gone. Fixed together because each fix on its own
leaves the others able to serve the object back.

## What was wrong, and what each fix does

### #87 — `Delete` returned nil when a non-primary delete failed

A failure at any non-primary site was logged at Warn and discarded, and `Delete`
returned nil. Nothing retried it — no tombstone, no queued job, no second
attempt — and `Get` takes the first site that answers, so the surviving replica
was served indefinitely. The API reported an erasure and then kept handing the
object back, with no signal to the operator.

`Delete` is now all-or-report: it returns nil only when every routed site
confirms the object is gone, otherwise an error wrapping the new
`ErrDeleteIncomplete` that names the sites which may still hold it, plus
`globalfs_delete_incomplete_total`.

Two changes of behaviour worth flagging:

- **Every routed site is attempted, even after one fails.** The old code
  returned on the first primary error, which left the replicas untouched and so
  maximised the number of surviving copies of an object the caller wanted gone.
- **"No such key" from a site counts as gone**, not as a failure. Without that,
  every retry of an already-completed delete would report incomplete forever and
  "retry the same `Delete`" would not be usable advice.

This is option 2 from the issue. Option 1 (a persisted, retried delete job) is
the correct end state but depends on the metadata store, and `SetStore` has no
non-test callers in any shipped deployment, so there was nothing to build on.

### #88 — a burst-only policy route made `Delete` an unconditional no-op

`Put` promoted the first non-primary to a synchronous target when the routed set
had no primaries; `Delete`, which partitions identically, never grew the
counterpart. Under a `TargetRoles: [burst]` delete rule every site landed in the
discard-errors loop, so `Delete` returned nil under every outcome, including
deleting nothing at all.

The promotion is now `partitionForWrite`, shared by both, as the issue asked —
the two had already drifted apart once and neither call site shows the omission
on its own.

### #91 — `Put`'s error path skipped cache invalidation

`Put` writes primaries sequentially and returns on the first error; the
invalidation sat after that early return. With two primaries where the second
fails, primary-1 held the new value, primary-2 the old one, the caller was told
the write failed, and readers kept getting the pre-`Put` value from cache — with
`TTL` defaulting to 0, until the process restarted.

The invalidation is now a `defer` taken before any site is written, so it covers
the early returns by construction rather than by remembering to copy it above
each new `return`.

### #92 — in-flight replication re-created a deleted object

`transfer()` read the source and wrote the destination with nothing in between
that could observe a concurrent delete, so a `PUT` landing after a completed
delete resurrected the object at the destination — usually a burst site nobody
watches — which `Get` then served.

`transfer` now `Head`s the source immediately before the destination `Put` and
abandons the transfer if the key has gone. The check is deliberately asymmetric:
only a code-matched "no such key" abandons, because reading an unreachable source
as a delete would silently stop replicating for the duration of any source
incident. An abandoned transfer settles as `EventCompleted` with **no** content
hash — recording one would make the dedup index claim the destination holds
content it does not.

## Scope, and what is deliberately left out

- **The `Head` → `Put` gap in #92 remains.** Closing it needs `Delete` to
  invalidate queued jobs for a key, which needs durable delete state — the
  unwired metadata store. This is the recommended narrowing, not a full fix.
- **The read path is untouched.** #87's "`Get` resurrects the object" symptom is
  demonstrated by a test here, which asserts `Get`'s *current* first-success-wins
  behaviour. Changing it was out of scope.
- **Primary divergence after a failed multi-primary `Put`** (no rollback, no
  repair) is untouched; #91 is scoped to the cache, where the fix is unambiguous.
- **`cmd/coordinator/api.go` is unchanged.** `Delete`'s signature did not change,
  so the existing 502 mapping compiles and stays defensible. It now tells the
  client less than it could — a partial delete with named sites and a safe retry
  is not the same as a delete that achieved nothing — and that is noted at the
  code for whoever refines the handler.
- **`CHANGELOG.md` is untouched**, per the maintainer's reservation.

## Test evidence

Every fix has a test that fails before it and passes after, verified by
reverting each fix in turn against the new tests.

`#87`/`#88` — with the old `Delete` body restored (6 failures):

```
--- FAIL: TestCoordinator_Delete_NonPrimaryErrorIsReported
    Delete returned nil while the burst site still holds the object (#87)
--- FAIL: TestCoordinator_Delete_IncompleteDeleteLeavesObjectReadable
    Delete reported success for an object that is still present at the burst site
--- FAIL: TestCoordinator_Delete_IncompleteIncrementsCounter
--- FAIL: TestCoordinator_Delete_AllSitesAttemptedAfterPrimaryFailure
    backup still holds the object: Delete stopped at the first primary failure
--- FAIL: TestCoordinator_Delete_BurstOnlyRouteReportsFailure
    Delete on a burst-only route returned nil although nothing was deleted anywhere (#88)
--- FAIL: TestCoordinator_Delete_NotFoundIsNotIncomplete
--- FAIL: TestCoordinator_Delete_ErrorPathStillInvalidatesCache
```

`#91` — with the `defer` disabled and the invalidation back at the end:

```
--- FAIL: TestCoordinator_Put_ErrorPathStillInvalidatesCache
    Get served the pre-Put value from a cache that was never invalidated, even
    though primary-1 had already been mutated; with TTL 0 that is indefinite (#91)
    Get returned "A", want primary-1's "B"
```

`#92` — with the pre-`Put` source check disabled:

```
--- FAIL: TestTransfer_AbandonsWhenSourceKeyDeletedMidFlight
    the destination has the object after a completed delete: the in-flight
    transfer resurrected it, and Coordinator.Get will serve it (#92)
    abandoned transfer returned content hash "70ce871f..."; nothing was written
--- FAIL: TestWorker_DeletedMidFlightIsNotResurrected
    destination has the object after the delete completed (#92)
```

All pass after. Full suite:

- `go build ./...` — clean
- `go test -race ./...` — all 15 packages pass (testcache cleared)
- `gofmt -l .` — empty
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` — no new
  findings in the touched packages versus the baseline on `main`

## Notes on the issues themselves

- **#87's line references are stale** (pre-v0.2.2), and its quoted snippet shows
  `cb.RecordFailure`/`RecordSuccess` called directly. Those were already replaced
  by `recordSiteResult`, which routes through `isSiteFailure` and correctly counts
  a not-found as a success (#77). The behavioural diagnosis was right; the code
  shown was not current.
- **#88's suggested patch is incomplete on its own.** The issue says so, and it
  is worth restating: adding the promotion without #87 converts "always nil" into
  "nil unless the one promoted site fails". Both loops had to start reporting.
- **#92's "no re-check at PUT time"** is accurate, but the pre-existing checksum
  fast path already `Head`s the source at the top of `transfer` — that `Head` just
  happens before the `GET`, where it cannot help. Worth knowing when reading the
  diff, since `transfer` now `Head`s the source twice on the slow path.
- **A trap the issues do not mention:** once the promotion is shared,
  `primaries` aliases `others`' backing array, so `append(primaries, others...)`
  would write through into the slice being appended from. `Delete` builds its
  target list into a fresh slice, and a test asserts each routed site sees exactly
  one `Delete`.
- **`failClient.Head` in the replication tests was a stub returning
  `(nil, nil)`** for every key, which would have made the new guard vacuous in
  every test that goes near it. It now answers from the same map `Get` and `Put`
  use, and reports absence with the code-matched objectfs error.